### PR TITLE
Stack traces for crashes

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -119,17 +119,22 @@ jobs:
           cd /lok/libreoffice-core
           ./autogen.sh --with-distro=LOKit-Linux --with-external-tar="/external-tar"
           make build
+          cd /lok
+          ./scripts/extract-symbols.sh
       - name: Make artifact
         run: |
           cd /lok/libreoffice-core
           /usr/bin/tar -cJf libreofficekit.tar.xz instdir
           cp libreofficekit.tar.xz $GITHUB_WORKSPACE/libreofficekit-linux.tar.xz
+          (cd workdir && /usr/bin/tar -cJf ../debug-symbols.tar.xz debug)
+          cp debug-symbols.tar.xz $GITHUB_WORKSPACE/debug-symbols-linux.tar.xz
           cd $GITHUB_WORKSPACE
           sha256sum libreofficekit-linux.tar.xz > libreofficekit-linux.tar.xz.sha256sum
+          sha256sum debug-symbols-linux.tar.xz > debug-symbols-linux.tar.xz.sha256sum
       - name: Create release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "libreofficekit-linux.tar.xz,libreofficekit-linux.tar.xz.sha256sum"
+          artifacts: "libreofficekit-linux.tar.xz,libreofficekit-linux.tar.xz.sha256sum,debug-symbols-linux.tar.xz,debug-symbols-linux.tar.xz.sha256sum"
           allowUpdates: true
           artifactErrorsFailBuild: true
           name: ${{ needs.check_version.outputs.version }}

--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -36,11 +36,14 @@ jobs:
           make build
           tar -cJf ../libreofficekit-mac-${{ matrix.arch }}.tar.xz instdir
           cd ..
+          ./scripts/extract-symbols-mac.sh
+          (cd workdir && /usr/bin/tar -cJf ../debug-symbols-mac-${{ matrix.arch }}.tar.xz debug)
           shasum -a 256 libreofficekit-mac-${{ matrix.arch }}.tar.xz > libreofficekit-mac-${{ matrix.arch }}.tar.xz.sha256sum
+          shasum -a 256 debug-symbols-mac-${{ matrix.arch }}.tar.xz > debug-symbols-mac-${{ matrix.arch }}.tar.xz.sha256sum
       - name: Create release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "libreofficekit-mac-${{ matrix.arch }}.tar.xz,libreofficekit-mac-${{ matrix.arch }}.tar.xz.sha256sum"
+          artifacts: "libreofficekit-mac-${{ matrix.arch }}.tar.xz,libreofficekit-mac-${{ matrix.arch }}.tar.xz.sha256sum,debug-symbols-mac-${{ matrix.arch }}.tar.xz,debug-symbols-mac-${{ matrix.arch }}.tar.xz.sha256sum"
           allowUpdates: true
           artifactErrorsFailBuild: true
           name: ${{ needs.check_version.outputs.version }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 libreoffice-core/.clangd
 libreoffice-core/diag.json
 libreoffice-core/vs-code-template.code-workspace
+
+.DS_Store

--- a/libreoffice-core/desktop/Library_sofficeapp.mk
+++ b/libreoffice-core/desktop/Library_sofficeapp.mk
@@ -132,6 +132,7 @@ $(eval $(call gb_Library_add_exception_objects,sofficeapp,\
 # LibreOfficeKit bits
 ifneq ($(filter $(OS),ANDROID iOS MACOSX WNT),)
 $(eval $(call gb_Library_add_exception_objects,sofficeapp,\
+    desktop/source/app/crashreport \
 	desktop/source/lib/init \
 	desktop/source/lib/lokdocumenteventnotifier \
 	desktop/source/lib/lokinteractionhandler \
@@ -146,6 +147,7 @@ $(if $(filter-out $(OS),IOS), \
 else
 ifneq ($(filter TRUE,$(USING_X11) $(DISABLE_GUI))($filter EMSCRIPTEN,$(OS)),)
 $(eval $(call gb_Library_add_exception_objects,sofficeapp,\
+    desktop/source/app/crashreport \
 	desktop/source/lib/init \
 	desktop/source/lib/lokdocumenteventnotifier \
 	desktop/source/lib/lokinteractionhandler \

--- a/libreoffice-core/desktop/source/app/app.cxx
+++ b/libreoffice-core/desktop/source/app/app.cxx
@@ -1128,6 +1128,7 @@ void Desktop::Exception(ExceptionCategory nCategory)
 {
     // protect against recursive calls
     static bool bInException = false;
+    CrashReporter::warnForBacktrace();
 
 #if HAVE_FEATURE_BREAKPAD
     CrashReporter::removeExceptionHandler(); // disallow re-entry

--- a/libreoffice-core/desktop/source/lib/init.cxx
+++ b/libreoffice-core/desktop/source/lib/init.cxx
@@ -4787,6 +4787,11 @@ static void doc_postUnoCommand(LibreOfficeKitDocument* pThis, const char* pComma
     int nView = SfxLokHelper::getView();
     if (nView < 0)
         return;
+    if (gImpl && aCommand == ".uno:TestCrash")
+    {
+        volatile int* p = 0;
+        *p = 0;
+    }
 
     if (gImpl && aCommand == ".uno:CreateTable")
     {

--- a/libreoffice-core/desktop/source/lib/init.cxx
+++ b/libreoffice-core/desktop/source/lib/init.cxx
@@ -9,9 +9,11 @@
 
 #include "comphelper/seqstream.hxx"
 #include "lib/unov8.hxx"
+#include "sal/backtrace.hxx"
 #include "sfx2/lokhelper.hxx"
 #include <config_buildconfig.h>
 #include <config_features.h>
+#include <desktop/crashreport.hxx>
 
 #include <stdio.h>
 #include <string.h>
@@ -4771,7 +4773,9 @@ static void doc_postUnoCommand(LibreOfficeKitDocument* pThis, const char* pComma
     SetLastExceptionMsg();
 
     SfxObjectShell* pDocSh = SfxObjectShell::Current();
-    OUString aCommand(pCommand, strlen(pCommand), RTL_TEXTENCODING_UTF8);
+    const std::string_view svCommand(pCommand);
+    CrashReporter::logUnoCommand(svCommand);
+    OUString aCommand = std::move(OUString::fromUtf8(svCommand));
     LibLODocument_Impl* pDocument = static_cast<LibLODocument_Impl*>(pThis);
 
     std::vector<beans::PropertyValue> aPropertyValuesVector(jsonToPropertyValuesVector(pArguments));
@@ -6103,6 +6107,7 @@ static char* doc_getCommandValues(LibreOfficeKitDocument* pThis, const char* pCo
     SetLastExceptionMsg();
 
     const std::string_view aCommand(pCommand);
+    CrashReporter::logCommandValues(aCommand);
     static constexpr OStringLiteral aViewRowColumnHeaders(".uno:ViewRowColumnHeaders");
     static constexpr OStringLiteral aSheetGeometryData(".uno:SheetGeometryData");
     static constexpr OStringLiteral aCellCursor(".uno:CellCursor");

--- a/libreoffice-core/distro-configs/LOKit-Linux.conf
+++ b/libreoffice-core/distro-configs/LOKit-Linux.conf
@@ -55,7 +55,7 @@
 --enable-release-build
 --disable-lotuswordpro
 --disable-lpsolve
---disable-symbols
+--enable-symbols
 --enable-sal-log
 --disable-report-builder
 --disable-breakpad

--- a/libreoffice-core/distro-configs/LOKit-Mac.conf
+++ b/libreoffice-core/distro-configs/LOKit-Mac.conf
@@ -52,7 +52,7 @@
 --enable-release-build
 --disable-lotuswordpro
 --disable-lpsolve
---disable-symbols
+--enable-symbols
 --enable-sal-log
 --disable-report-builder
 --disable-breakpad

--- a/libreoffice-core/include/desktop/crashreport.hxx
+++ b/libreoffice-core/include/desktop/crashreport.hxx
@@ -22,11 +22,10 @@
 #include <vector>
 #include <deque>
 #include <string>
+#include <string_view>
 
 namespace google_breakpad
-{
-class ExceptionHandler;
-}
+{ class ExceptionHandler; }
 
 /**
  * Provides access to the crash reporter service.
@@ -111,6 +110,19 @@ private:
         return OUString();
     }
 #endif // HAVE_FEATURE_BREAKPAD
+public:
+    static void logUnoCommand(std::string_view command);
+
+    static void logCommandValues(std::string_view command);
+
+    static void logUnoV8(const std::string_view& ns, const std::string_view& func);
+
+    static void warnForBacktrace();
+private:
+    static std::deque<std::string> unoCommands;
+    static std::deque<std::string> commandValues;
+    static std::deque<std::string_view> unoV8Class;
+    static std::deque<std::string_view> unoV8Func;
 };
 
 #endif // INCLUDED_DESKTOP_CRASHREPORT_HXX

--- a/libreoffice-core/sal/osl/unx/backtraceapi.cxx
+++ b/libreoffice-core/sal/osl/unx/backtraceapi.cxx
@@ -131,7 +131,7 @@ void process_file_addr2line(std::string_view file, std::vector<FrameData>& frame
             if (!frame.file.empty() && file == frame.file)
             {
                 frame.info
-                    = "[+0x" + OString::number(frame.offset, 16) + "]" + OString(basename(file));
+                    = "[+0x" + OString::number(frame.offset, 16) + "](" + OString(basename(file)) + ")";
                 std::lock_guard guard(frameCacheMutex);
                 frameCache.insert({ frame.addr, frame.info });
             }
@@ -243,7 +243,7 @@ void process_file_addr2line(std::string_view file, std::vector<FrameData>& frame
                     linesPos++;
                 ++linesPos;
                 frame.info
-                    = "[+0x" + OString::number(frame.offset, 16) + "](" + OString(basename(file)) ")";
+                    = "[+0x" + OString::number(frame.offset, 16) + "](" + OString(basename(file)) + ")";
                 std::lock_guard guard(frameCacheMutex);
                 frameCache.insert({ frame.addr, frame.info });
                 continue;

--- a/libreoffice-core/sal/osl/unx/backtraceapi.cxx
+++ b/libreoffice-core/sal/osl/unx/backtraceapi.cxx
@@ -24,26 +24,29 @@
 
 #include "backtrace.h"
 #include <backtraceasstring.hxx>
+#include <string_view>
 
-OUString osl::detail::backtraceAsString(sal_uInt32 maxDepth) {
-    std::unique_ptr<sal::BacktraceState> backtrace = sal::backtrace_get( maxDepth );
-    return sal::backtrace_to_string( backtrace.get());
+OUString osl::detail::backtraceAsString(sal_uInt32 maxDepth)
+{
+    std::unique_ptr<sal::BacktraceState> backtrace = sal::backtrace_get(maxDepth);
+    return sal::backtrace_to_string(backtrace.get());
 }
 
 std::unique_ptr<sal::BacktraceState> sal::backtrace_get(sal_uInt32 maxDepth)
 {
     assert(maxDepth != 0);
-    auto const maxInt = static_cast<unsigned int>(
-        std::numeric_limits<int>::max());
-    if (maxDepth > maxInt) {
+    auto const maxInt = static_cast<unsigned int>(std::numeric_limits<int>::max());
+    if (maxDepth > maxInt)
+    {
         maxDepth = static_cast<sal_uInt32>(maxInt);
     }
-    auto b1 = new void *[maxDepth];
+    auto b1 = new void*[maxDepth];
     int n = backtrace(b1, static_cast<int>(maxDepth));
     return std::unique_ptr<BacktraceState>(new BacktraceState{ b1, n });
 }
 
-#if OSL_DEBUG_LEVEL > 0 && (defined LINUX || defined MACOSX || defined FREEBSD || defined NETBSD || defined OPENBSD || defined(DRAGONFLY))
+#if (defined LINUX || defined MACOSX || defined FREEBSD || defined NETBSD || defined OPENBSD       \
+     || defined(DRAGONFLY))
 // The backtrace_symbols() function is unreliable, it requires -rdynamic and even then it cannot resolve names
 // of many functions, such as those with hidden ELF visibility. Libunwind doesn't resolve names for me either,
 // boost::stacktrace doesn't work properly, the best result I've found is addr2line. Using addr2line is relatively
@@ -62,7 +65,7 @@ namespace
 {
 struct FrameData
 {
-    const char* file = nullptr;
+    std::string_view file;
     void* addr;
     ptrdiff_t offset;
     OString info;
@@ -71,31 +74,54 @@ struct FrameData
 
 typedef o3tl::lru_map<void*, OString> FrameCache;
 std::mutex frameCacheMutex;
-FrameCache frameCache( 256 );
+FrameCache frameCache(256);
 
-void process_file_addr2line( const char* file, std::vector<FrameData>& frameData )
+std::string_view basename(std::string_view path)
 {
-    if(access( file, R_OK ) != 0)
-        return; // cannot read info from the binary file anyway
-    OUString binary("addr2line");
+    auto split_pos = path.rfind('/');
+    if (split_pos != std::string_view::npos)
+    {
+        return path.substr(split_pos + 1);
+    }
+    return {};
+}
+
+void process_file_addr2line(std::string_view file, std::vector<FrameData>& frameData)
+{
+    // if(access( file, R_OK ) != 0)
+    //     return; // cannot read info from the binary file anyway
+    OUString binary("llvm-symbolizer");
     OUString dummy;
-#if defined __clang__
-    // llvm-addr2line is faster than addr2line
-    if(osl::detail::find_in_PATH("llvm-addr2line", dummy))
-        binary = "llvm-addr2line";
-#endif
-    if(!osl::detail::find_in_PATH(binary, dummy))
-        return; // Will not work, avoid warnings from osl process code.
-    OUString arg1("-Cfe");
+    if (osl::detail::find_in_PATH("llvm-symbolizer-14", dummy))
+        binary = "llvm-symbolizer-14";
+    if (osl::detail::find_in_PATH("llvm-symbolizer-15", dummy))
+        binary = "llvm-symbolizer-15";
+    if (osl::detail::find_in_PATH("llvm-symbolizer-16", dummy))
+        binary = "llvm-symbolizer-16";
+    if (!osl::detail::find_in_PATH(binary, dummy))
+    {
+        for (FrameData& frame : frameData)
+        {
+            if (!frame.file.empty() && file == frame.file)
+            {
+                frame.info
+                    = "[+0x" + OString::number(frame.offset, 16) + "]" + OString(basename(file));
+                std::lock_guard guard(frameCacheMutex);
+                frameCache.insert({ frame.addr, frame.info });
+            }
+        }
+        return;
+    }
+    OUString arg1("-Cfpe");
     OUString arg2 = OUString::fromUtf8(file);
     std::vector<OUString> addrs;
     std::vector<rtl_uString*> args;
     args.reserve(frameData.size() + 2);
-    args.push_back( arg1.pData );
-    args.push_back( arg2.pData );
-    for( FrameData& frame : frameData )
+    args.push_back(arg1.pData);
+    args.push_back(arg2.pData);
+    for (FrameData& frame : frameData)
     {
-        if( frame.file != nullptr && strcmp( file, frame.file ) == 0 )
+        if (!frame.file.empty() && file == frame.file)
         {
             addrs.push_back("0x" + OUString::number(frame.offset, 16));
             args.push_back(addrs.back().pData);
@@ -108,8 +134,8 @@ void process_file_addr2line( const char* file, std::vector<FrameData>& frameData
     oslFileHandle pErr = nullptr;
     oslSecurity pSecurity = osl_getCurrentSecurity();
     oslProcessError eErr = osl_executeProcess_WithRedirectedIO(
-        binary.pData, args.data(), args.size(), osl_Process_SEARCHPATH | osl_Process_HIDDEN, pSecurity, nullptr,
-        nullptr, 0, &aProcess, nullptr, &pOut, &pErr);
+        binary.pData, args.data(), args.size(), osl_Process_SEARCHPATH | osl_Process_HIDDEN,
+        pSecurity, nullptr, nullptr, 0, &aProcess, nullptr, &pOut, &pErr);
     osl_freeSecurityHandle(pSecurity);
 
     if (eErr != osl_Process_E_None)
@@ -126,11 +152,11 @@ void process_file_addr2line( const char* file, std::vector<FrameData>& frameData
         while (true)
         {
             sal_uInt64 bytesRead = 0;
-            while(osl_readFile(pErr, buffer, BUF_SIZE, &bytesRead) == osl_File_E_None
-                && bytesRead != 0)
+            while (osl_readFile(pErr, buffer, BUF_SIZE, &bytesRead) == osl_File_E_None
+                   && bytesRead != 0)
                 ; // discard possible stderr output
             oslFileError err = osl_readFile(pOut, buffer, BUF_SIZE, &bytesRead);
-            if(bytesRead == 0 && err == osl_File_E_None)
+            if (bytesRead == 0 && err == osl_File_E_None)
                 break;
             outputBuffer.append(buffer, bytesRead);
             if (err != osl_File_E_None && err != osl_File_E_AGAIN)
@@ -138,7 +164,7 @@ void process_file_addr2line( const char* file, std::vector<FrameData>& frameData
         }
         osl_closeFile(pOut);
     }
-    if(pErr)
+    if (pErr)
         osl_closeFile(pErr);
     eErr = osl_joinProcess(aProcess);
     osl_freeProcessHandle(aProcess);
@@ -146,48 +172,56 @@ void process_file_addr2line( const char* file, std::vector<FrameData>& frameData
     OString output = outputBuffer.makeStringAndClear();
     std::vector<OString> lines;
     sal_Int32 outputPos = 0;
-    while(outputPos < output.getLength())
+    while (outputPos < output.getLength())
     {
         sal_Int32 end1 = output.indexOf('\n', outputPos);
-        if(end1 < 0)
+        if (end1 < 0)
             break;
         sal_Int32 end2 = output.indexOf('\n', end1 + 1);
-        if(end2 < 0)
+        if (end2 < 0)
             end2 = output.getLength();
-        lines.push_back(output.copy( outputPos, end1 - outputPos ));
-        lines.push_back(output.copy( end1 + 1, end2 - end1 - 1 ));
+        lines.push_back(output.copy(outputPos, end1 - outputPos));
+        lines.push_back(output.copy(end1 + 1, end2 - end1 - 1));
         outputPos = end2 + 1;
     }
-    if(lines.size() != addrs.size() * 2)
-    {
-        SAL_WARN("sal.osl", "failed to parse " << binary << " call output to resolve " << file << " symbols ");
-        return; // addr2line problem?
-    }
     size_t linesPos = 0;
-    for( FrameData& frame : frameData )
+    static const std::string_view BAD_MATCH = " at ??:";
+    for (FrameData& frame : frameData)
     {
-        if( frame.file != nullptr && strcmp( file, frame.file ) == 0 )
+        if (!frame.file.empty() && file == frame.file)
         {
-            // There should be two lines, first function name and second source file information.
-            // If each of them starts with ??, it is invalid/unknown.
-            OString function = lines[linesPos];
-            OString source = lines[linesPos+1];
-            linesPos += 2;
-            if(function.isEmpty() || function.startsWith("??"))
+            if (linesPos >= lines.size())
+                break;
+
+            OStringBuffer lineBuffer;
+            if (lines[linesPos].indexOf(BAD_MATCH) != -1)
             {
-                // Cache that the address cannot be resolved.
+                // skip to next
+                while (linesPos < lines.size() && lines[linesPos].getLength() > 1)
+                    linesPos++;
+                ++linesPos;
+                frame.info
+                    = "[+0x" + OString::number(frame.offset, 16) + "]" + OString(basename(file));
                 std::lock_guard guard(frameCacheMutex);
-                frameCache.insert( { frame.addr, "" } );
+                frameCache.insert({ frame.addr, frame.info });
+                continue;
             }
-            else
+
+            while (linesPos < lines.size() && lines[linesPos].getLength() <= 1)
+                linesPos++;
+
+            while (linesPos < lines.size() && lines[linesPos].getLength() > 1)
             {
-                if( source.startsWith("??"))
-                    frame.info = function + " in " + file;
-                else
-                    frame.info = function + " at " + source;
-                std::lock_guard guard(frameCacheMutex);
-                frameCache.insert( { frame.addr, frame.info } );
+                lineBuffer.append(lines[linesPos]);
+                if (++linesPos < lines.size() && lines[linesPos].getLength() > 1)
+                {
+                    lineBuffer.append('\n');
+                }
             }
+            ++linesPos;
+            frame.info = lineBuffer.makeStringAndClear();
+            std::lock_guard guard(frameCacheMutex);
+            frameCache.insert({ frame.addr, frame.info });
         }
     }
 }
@@ -198,7 +232,7 @@ OUString sal::backtrace_to_string(BacktraceState* backtraceState)
 {
     // Collect frames for each binary and process each binary in one addr2line
     // call for better performance.
-    std::vector< FrameData > frameData;
+    std::vector<FrameData> frameData;
     frameData.resize(backtraceState->nDepth);
     for (int i = 0; i != backtraceState->nDepth; ++i)
     {
@@ -208,49 +242,46 @@ OUString sal::backtrace_to_string(BacktraceState* backtraceState)
         auto it = frameCache.find(addr);
         bool found = it != frameCache.end();
         guard.unlock();
-        if( found )
+        if (found)
         {
-            frameData[ i ].info = it->second;
-            frameData[ i ].handled = true;
+            frameData[i].info = it->second;
+            frameData[i].handled = true;
         }
         else if (dladdr(addr, &dli) != 0)
         {
             if (dli.dli_fname && dli.dli_fbase)
             {
-                frameData[ i ].file = dli.dli_fname;
-                frameData[ i ].addr = addr;
-                frameData[ i ].offset = reinterpret_cast<ptrdiff_t>(addr) - reinterpret_cast<ptrdiff_t>(dli.dli_fbase);
+                std::string_view file(dli.dli_fname);
+                auto split_pos = file.find(' ');
+                if (split_pos != std::string_view::npos)
+                {
+                    file = file.substr(0, split_pos);
+                }
+                frameData[i].file = file;
+                frameData[i].addr = addr;
+                frameData[i].offset = reinterpret_cast<ptrdiff_t>(addr)
+                                      - reinterpret_cast<ptrdiff_t>(dli.dli_fbase);
             }
         }
     }
-    for (int i = 0; i != backtraceState->nDepth; ++i)
+    for (int j = 0; j != backtraceState->nDepth; ++j)
     {
-        if(frameData[ i ].file != nullptr && !frameData[ i ].handled)
-            process_file_addr2line( frameData[ i ].file, frameData );
+        int i = j - 0;
+        if (!frameData[i].file.empty() && !frameData[i].handled)
+        {
+            process_file_addr2line(frameData[i].file, frameData);
+        }
     }
     OUStringBuffer b3;
     std::unique_ptr<char*, decltype(free)*> b2{ nullptr, free };
-    bool fallbackInitDone = false;
-    for (int i = 0; i != backtraceState->nDepth; ++i)
+    constexpr int offset = 7;
+    for (int i = offset; i != backtraceState->nDepth; ++i)
     {
-        if (i != 0)
+        if (i != offset)
             b3.append("\n");
-        b3.append( "#" + OUString::number( i ) + " " );
-        if(!frameData[i].info.isEmpty())
+        b3.append("#" + OUString::number(i - offset) + " ");
+        if (!frameData[i].info.isEmpty())
             b3.append(o3tl::runtimeToOUString(frameData[i].info.getStr()));
-        else
-        {
-            if(!fallbackInitDone)
-            {
-                b2 = std::unique_ptr<char*, decltype(free)*>
-                    {backtrace_symbols(backtraceState->buffer, backtraceState->nDepth), free};
-                fallbackInitDone = true;
-            }
-            if(b2)
-                b3.append(o3tl::runtimeToOUString(b2.get()[i]));
-            else
-                b3.append("??");
-        }
     }
     return b3.makeStringAndClear();
 }
@@ -259,16 +290,23 @@ OUString sal::backtrace_to_string(BacktraceState* backtraceState)
 
 OUString sal::backtrace_to_string(BacktraceState* backtraceState)
 {
-    std::unique_ptr<char*, decltype(free)*> b2{backtrace_symbols(backtraceState->buffer, backtraceState->nDepth), free};
-    if (!b2) {
+    std::unique_ptr<char*, decltype(free)*> b2{
+        backtrace_symbols(backtraceState->buffer, backtraceState->nDepth), free
+    };
+    if (!b2)
+    {
         return OUString();
     }
     OUStringBuffer b3;
-    for (int i = 0; i != backtraceState->nDepth; ++i) {
-        if (i != 0) {
+    for (int i = 3; i != backtraceState->nDepth; ++i)
+    {
+        if (i != 0)
+        {
             b3.append("\n");
         }
-        b3.append( "#" + OUString::number( i ) + " " );
+        b3.append("#" + OUString::number(i - 3) + " ");
+        o3tl::runtimeToOUString(b2.get()[i]);
+
         b3.append(o3tl::runtimeToOUString(b2.get()[i]));
     }
     return b3.makeStringAndClear();

--- a/libreoffice-core/sal/osl/unx/backtraceapi.cxx
+++ b/libreoffice-core/sal/osl/unx/backtraceapi.cxx
@@ -74,7 +74,7 @@ struct FrameData
 
 typedef o3tl::lru_map<void*, OString> FrameCache;
 std::mutex frameCacheMutex;
-FrameCache frameCache(256);
+FrameCache frameCache(64);
 
 std::string_view basename(std::string_view path)
 {
@@ -328,8 +328,11 @@ OUString sal::backtrace_to_string(BacktraceState* backtraceState)
         if (frameData[i].file.empty())
             continue;
         if (i != offset)
-            b3.append("\n");
-        b3.append("#" + OUString::number(i - offset) + " ");
+            b3.append('\n');
+        b3.append('#');
+        b3.append(i - offset);
+        b3.append(' ');
+
         if (!frameData[i].info.isEmpty())
             b3.append(o3tl::runtimeToOUString(frameData[i].info.getStr()));
     }

--- a/libreoffice-core/unoidl/source/v8/writer.hxx
+++ b/libreoffice-core/unoidl/source/v8/writer.hxx
@@ -218,6 +218,9 @@ public:
 
 private:
     void writeName(OUString const& name);
+    void writeInterfaceStaticName(OUString const& name,
+                               rtl::Reference<unoidl::InterfaceTypeEntity> entity, bool isRef,
+                               std::unordered_set<int>& declared);
     void writeInterfaceMethods(OUString const& name,
                                rtl::Reference<unoidl::InterfaceTypeEntity> entity, bool isRef,
                                std::unordered_set<int>& declared);

--- a/scripts/extract-symbols-mac.sh
+++ b/scripts/extract-symbols-mac.sh
@@ -7,7 +7,7 @@ D="$W/debug"
 echo "Preparing debug symbols for macOS..."
 mkdir -p "$D"
 rm -rf "${D:?}/*"
-[ "$(uname -m)" == 'arm64' ]; then
+if [ "$(uname -m)" == 'arm64' ]; then
   I="$I/aarch64"
 else
   I="$I/x64"

--- a/scripts/extract-symbols-mac.sh
+++ b/scripts/extract-symbols-mac.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+BASE=$(dirname "$(dirname "$0")")
+LO="$BASE/libreoffice-core"
+W="$LO/workdir"
+I="$LO/instdir"
+D="$W/debug"
+echo "Preparing debug symbols for macOS..."
+mkdir -p "$D"
+rm -rf "${D:?}/*"
+[ "$(uname -m)" == 'arm64' ]; then
+  I="$I/aarch64"
+else
+  I="$I/x64"
+fi
+for i in "$I"/program/*; do
+  echo -n "$i"
+  debug_name="$(basename "$i").dSYM" 
+  dsymutil "$i" -o "$D/$debug_name"
+  echo -n "."
+  strip -S "$i"
+  echo "."
+done

--- a/scripts/extract-symbols.sh
+++ b/scripts/extract-symbols.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+BASE=$(dirname "$(dirname "$0")")
+LO="$BASE/libreoffice-core"
+W="$LO/workdir"
+I="$LO/instdir"
+D="$W/debug"
+echo "Preparing debug symbols for Linux..."
+mkdir -p "$D"
+rm -rf "${D:?}/*"
+for i in "$I"/program/*; do
+  echo -n "$i"
+  debug_name="$(basename "$i").debug" 
+  objcopy --only-keep-debug --compress-debug-sections "$i" "$D/$debug_name"
+  echo -n "."
+  strip --discard-all --strip-debug --preserve-dates "$i"
+  echo -n "."
+  debug_file="$(realpath "$i")"
+  (cd "$D" && objcopy --add-gnu-debuglink="$debug_name" "$debug_file")
+  echo "."
+done

--- a/scripts/extract-symbols.sh
+++ b/scripts/extract-symbols.sh
@@ -10,7 +10,7 @@ rm -rf "${D:?}/*"
 for i in "$I"/program/*; do
   echo -n "$i"
   debug_name="$(basename "$i").debug" 
-  objcopy --only-keep-debug --compress-debug-sections "$i" "$D/$debug_name"
+  objcopy --only-keep-debug "$i" "$D/$debug_name"
   echo -n "."
   strip --discard-all --strip-debug --preserve-dates "$i"
   echo -n "."

--- a/scripts/resymbolize.js
+++ b/scripts/resymbolize.js
@@ -1,0 +1,68 @@
+const { execSync } = require("child_process");
+const path = require("path");
+const debugDir =
+  process.argv[2] || path.join(__dirname, "../libreoffice-core/workdir/debug");
+
+let llvmSymbolizer;
+
+["llvm-symbolizer-14", "llvm-symbolizer-15", "llvm-symbolizer-16"].some(
+  (command) => {
+    try {
+      execSync(`${command} --version`);
+      llvmSymbolizer = command;
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+);
+
+let stdinData = "";
+
+process.stdin.on("data", function (chunk) {
+  stdinData += chunk;
+});
+
+process.stdin.on("end", function () {
+  let symbolSuffix = ".debug";
+  if (stdinData.includes(".exe") || stdinData.includes(".dll")) {
+    symbolSuffix = ".pdb";
+  } else if (stdinData.includes(".dylib") || stdinData.includes(" Framework")) {
+    symbolSuffix = ".dSYM";
+  }
+
+  const re = /\[\+(0x[a-fA-F0-9]+)\]\(([^)]+)\)/g;
+  const matches = [...stdinData.matchAll(re)];
+
+  let groups = matches.reduce((acc, match) => {
+    const offset = match[1];
+    const file = match[2];
+
+    if (!acc[file]) {
+      acc[file] = [];
+    }
+
+    acc[file].push(offset);
+
+    return acc;
+  }, {});
+
+  for (let file in groups) {
+    const offsets = groups[file];
+    const debugFile = `${debugDir}/${file}${symbolSuffix}`;
+
+    const command = `${llvmSymbolizer} -Cfape ${debugFile} ${offsets.join(
+      " "
+    )}`;
+    const result = execSync(command).toString().split("\n\n");
+
+    for (let i = 0; i < offsets.length; i++) {
+      const offset = offsets[i];
+      const symbolizedLine = `${file}+${result[i]}`;
+      const regex = new RegExp(`\\[\\+${offset}\\]\\(${file}\\)`, "g");
+      stdinData = stdinData.replace(regex, symbolizedLine);
+    }
+  }
+
+  process.stdout.write(stdinData);
+});


### PR DESCRIPTION
- [x] macOS
  - [x] `--enable-symbols` in LOK-Mac
  - [x] Add macOS version of extract-symbols.sh using `dsymutil x.dylib -o x.dylib.dSYM` to extract debug symbols and `strip -S x.dylib` to remove the symbols
  - [x] Use `atos -i --fullPath -o x.dylib --offset 0x...` or `atos -i --fullPath -o x.dSYM --offset 0x...` to resolve symbols in backtraceapi.cxx
- [ ] Windows
  - [x] Review how Windows backtraceapi.cxx works, verify that symbols can be resolved using offsets and available PDBs
  - [ ] Copy PDBs from workdir\LinkTarget\Library for matching DLLs in instdir
  - [ ] Write stack trace that handles SEH like in Chromium by forwarding from signal.cxx
  - [ ] Handle in Desktop::Exception like with warnForBacktrace (but only on Windows)
- [x] Log last 5 postUnoCommand commands on Application::Abort
- [x] Log last 5 UNO V8 C methods on Application::Abort
- [x] Update CI to archive and post the debug symbols for each platform
- [x] Add a script to take a debug log with missing symbols and symbolize it