### PR TITLE
CHG switch ci to use beefy windows runner

### DIFF
--- a/.github/workflows/release-win.yml
+++ b/.github/workflows/release-win.yml
@@ -11,7 +11,7 @@ jobs:
   fetch:
     needs: [check_version]
     if: ${{ needs.check_version.outputs.should_run != 'false' }}
-    runs-on: windows-2019
+    runs-on: windows-2019-beefy
     name: Fetch external projects
     steps:
       - name: Turn off line ending conversion in git
@@ -99,7 +99,7 @@ jobs:
   build:
     needs: [check_version, fetch]
     if: ${{ needs.check_version.outputs.should_run != 'false' }}
-    runs-on: windows-2019
+    runs-on: windows-2019-beefy
     name: Build
     steps:
       - name: Turn off line ending conversion in git


### PR DESCRIPTION
looks like the ci for windows ci build is failing, im taking a guess that adding debug symbols is making the default windows runner run out of resources. So i've created a custom 8core 32gb ram 600gbssd runner.

```
C:\lok\libreoffice-core\sfx2\source\appl\appcfg.cxx(110) : fatal error C1002: compiler is out of heap space in pass 2
C:\lok\libreoffice-core\vcl\jsdialog\enabled.cxx(17) : fatal error C1002: compiler is out of heap space in pass 2
LINK : fatal error LNK1257: code generation failed
C:\lok\libreoffice-core\include\com\sun\star\uno\Reference.hxx(365) : fatal error C1002: compiler is out of heap space in pass 2
C:\lok\libreoffice-core\include\cppu\unotype.hxx(300) : fatal error C1002: compiler is out of heap space in pass 2
touch: failed to get attributes of 'C:/lok/libreoffice-core/instdir/program/mergedlo.dll': No such file or directory
make[1]: *** [C:/lok/libreoffice-core/Library_merged.mk:11: C:/lok/libreoffice-core/instdir/program/mergedlo.dll] Error 233
make: *** [Makefile:265: build] Error
```

https://github.com/organizations/coparse-inc/settings/actions/github-hosted-runners/1?viewing_from_runner_group=false
here is the runner

