### PR TITLE
teo/fix/clicking between pages unrenders document [MACRO-1280]

### DIFF
--- a/libreoffice-core/sw/source/uibase/docvw/edtwin.cxx
+++ b/libreoffice-core/sw/source/uibase/docvw/edtwin.cxx
@@ -623,8 +623,10 @@ void SwEditWin::UpdatePointer(const Point &rLPt, sal_uInt16 nModifier )
         }
 
         // which kind of text pointer have we to show - horz / vert - ?
-        // NOTE: @teo turning off show/hide whitespace between pages
 
+
+        // NOTE: @teo turning off show/hide whitespace between pages
+        // https://www.notion.so/macrocom/Rendering-Issues-clicking-between-Pages-9eef9ecf67c54542ad74adefdefd7315
 
         /* if( PointerStyle::Text == eStyle && rSh.IsInVerticalText( &rLPt )) */
         /*     eStyle = PointerStyle::TextVertical; */
@@ -3035,6 +3037,7 @@ void SwEditWin::MouseButtonDown(const MouseEvent& _rMEvt)
 
         // Toggle Hide-Whitespace if between pages.
         // NOTE: @teo turning off show/hide whitespaces
+        // https://www.notion.so/macrocom/Rendering-Issues-clicking-between-Pages-9eef9ecf67c54542ad74adefdefd7315
 
         /* if (rSh.GetViewOptions()->CanHideWhitespace() && */
         /*     rSh.GetLayout()->IsBetweenPages(aDocPos)) */

--- a/libreoffice-core/sw/source/uibase/docvw/edtwin.cxx
+++ b/libreoffice-core/sw/source/uibase/docvw/edtwin.cxx
@@ -625,8 +625,7 @@ void SwEditWin::UpdatePointer(const Point &rLPt, sal_uInt16 nModifier )
         // which kind of text pointer have we to show - horz / vert - ?
 
 
-        // NOTE: @teo turning off show/hide whitespace between pages
-        // https://www.notion.so/macrocom/Rendering-Issues-clicking-between-Pages-9eef9ecf67c54542ad74adefdefd7315
+        // [MACRO-1280]: fix rendering issues caused by clicking between pages
 
         /* if( PointerStyle::Text == eStyle && rSh.IsInVerticalText( &rLPt )) */
         /*     eStyle = PointerStyle::TextVertical; */
@@ -3036,8 +3035,7 @@ void SwEditWin::MouseButtonDown(const MouseEvent& _rMEvt)
         }
 
         // Toggle Hide-Whitespace if between pages.
-        // NOTE: @teo turning off show/hide whitespaces
-        // https://www.notion.so/macrocom/Rendering-Issues-clicking-between-Pages-9eef9ecf67c54542ad74adefdefd7315
+        // [MACRO-1280]: fix rendering issues caused by clicking between pages
 
         /* if (rSh.GetViewOptions()->CanHideWhitespace() && */
         /*     rSh.GetLayout()->IsBetweenPages(aDocPos)) */

--- a/libreoffice-core/sw/source/uibase/docvw/edtwin.cxx
+++ b/libreoffice-core/sw/source/uibase/docvw/edtwin.cxx
@@ -623,16 +623,19 @@ void SwEditWin::UpdatePointer(const Point &rLPt, sal_uInt16 nModifier )
         }
 
         // which kind of text pointer have we to show - horz / vert - ?
-        if( PointerStyle::Text == eStyle && rSh.IsInVerticalText( &rLPt ))
-            eStyle = PointerStyle::TextVertical;
-        else if (rSh.GetViewOptions()->CanHideWhitespace() &&
-                 rSh.GetLayout()->IsBetweenPages(rLPt))
-        {
-            if (rSh.GetViewOptions()->IsHideWhitespaceMode())
-                eStyle = PointerStyle::ShowWhitespace;
-            else
-                eStyle = PointerStyle::HideWhitespace;
-        }
+        // NOTE: @teo turning off show/hide whitespace between pages
+
+
+        /* if( PointerStyle::Text == eStyle && rSh.IsInVerticalText( &rLPt )) */
+        /*     eStyle = PointerStyle::TextVertical; */
+        /* else if (rSh.GetViewOptions()->CanHideWhitespace() && */
+        /*          rSh.GetLayout()->IsBetweenPages(rLPt)) */
+        /* { */
+        /*     if (rSh.GetViewOptions()->IsHideWhitespaceMode()) */
+        /*         eStyle = PointerStyle::ShowWhitespace; */
+        /*     else */
+        /*         eStyle = PointerStyle::HideWhitespace; */
+        /* } */
 
         SetPointer( eStyle );
     }
@@ -3031,18 +3034,20 @@ void SwEditWin::MouseButtonDown(const MouseEvent& _rMEvt)
         }
 
         // Toggle Hide-Whitespace if between pages.
-        if (rSh.GetViewOptions()->CanHideWhitespace() &&
-            rSh.GetLayout()->IsBetweenPages(aDocPos))
-        {
-            if (_rMEvt.GetClicks() >= 2)
-            {
-                SwViewOption aOpt(*rSh.GetViewOptions());
-                aOpt.SetHideWhitespaceMode(!aOpt.IsHideWhitespaceMode());
-                rSh.ApplyViewOptions(aOpt);
-            }
+        // NOTE: @teo turning off show/hide whitespaces
 
-            return;
-        }
+        /* if (rSh.GetViewOptions()->CanHideWhitespace() && */
+        /*     rSh.GetLayout()->IsBetweenPages(aDocPos)) */
+        /* { */
+        /*     if (_rMEvt.GetClicks() >= 1) */
+        /*     { */
+        /*         SwViewOption aOpt(*rSh.GetViewOptions()); */
+        /*         aOpt.SetHideWhitespaceMode(!aOpt.IsHideWhitespaceMode()); */
+        /*         rSh.ApplyViewOptions(aOpt); */
+        /*     } */
+
+        /*     return; */
+        /* } */
     }
 
     if ( IsChainMode() )


### PR DESCRIPTION
When clicking between pages it toggles hiding/showing whitespace on a document, which breaks the document render.
But I dont think we want the functionality of this between pages anyway so turning it off.

Fixed:
https://www.loom.com/share/5659a28cc00f49878d520133489c3008

Before in monorepo:
https://www.loom.com/share/b27d290307e94c228da1687633342a03
