### PR TITLE
Add red/blue colorization and comparison list formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ libreoffice-core/vs-code-template.code-workspace
 
 .DS_Store
 libreoffice-core/debug
+.vscode/**/*
+.idea/**/*

--- a/libreoffice-core/include/tools/color.hxx
+++ b/libreoffice-core/include/tools/color.hxx
@@ -500,6 +500,8 @@ inline constexpr ::Color COL_AUTHOR_TABLE_DEL        ( 0xFC, 0xE6, 0xF4 );
 inline constexpr ::Color COL_PIP_TERM                ( 0x14, 0x46, 0xA3 );
 inline constexpr ::Color COL_PIP_TERM_REF            ( 0x14, 0x46, 0xA3 );
 inline constexpr ::Color COL_PIP_SECTION_REF         ( 0x4C, 0xAF, 0x50 );
+inline constexpr ::Color COL_RED_CLASSIC             ( 0xFF, 0x00, 0x00 );
+inline constexpr ::Color COL_BLUE_CLASSIC            ( 0x00, 0x00, 0xFF );
 
 template<typename charT, typename traits>
 inline std::basic_ostream<charT, traits>& operator <<(std::basic_ostream<charT, traits>& rStream, const Color& rColor)

--- a/libreoffice-core/sw/inc/swmodule.hxx
+++ b/libreoffice-core/sw/inc/swmodule.hxx
@@ -204,9 +204,9 @@ public:
     std::size_t         InsertRedlineAuthor(const OUString& rAuthor);
     void                SetRedlineAuthor(const OUString& rAuthor); // for unit tests
 
-    void                GetInsertAuthorAttr(std::size_t nAuthor, SfxItemSet &rSet);
-    void                GetDeletedAuthorAttr(std::size_t nAuthor, SfxItemSet &rSet);
-    void                GetFormatAuthorAttr(std::size_t nAuthor, SfxItemSet &rSet);
+    void                GetInsertAuthorAttr(SfxItemSet &rSet);
+    void                GetDeletedAuthorAttr(SfxItemSet &rSet);
+    void                GetFormatAuthorAttr(SfxItemSet &rSet);
 
     sal_uInt16              GetRedlineMarkPos() const;
     const Color&            GetRedlineMarkColor() const;

--- a/libreoffice-core/sw/source/core/text/redlnitr.cxx
+++ b/libreoffice-core/sw/source/core/text/redlnitr.cxx
@@ -792,9 +792,8 @@ short SwRedlineItr::Seek(SwFont& rFnt,
                         m_pSet = std::make_unique<SfxItemSetFixed<RES_CHRATR_BEGIN, RES_CHRATR_END-1>>(rPool);
                     }
 
-                    if( 1 < pRed->GetStackCount() )
-                        FillHints( pRed->GetAuthor( 1 ), pRed->GetType( 1 ) );
-                    FillHints( pRed->GetAuthor(), pRed->GetType() );
+
+                    FillHints( pRed->GetType() );
 
                     SfxWhichIter aIter( *m_pSet );
 
@@ -866,7 +865,7 @@ short SwRedlineItr::Seek(SwFont& rFnt,
     return nRet + EnterExtend(rFnt, nNode, nNew);
 }
 
-void SwRedlineItr::FillHints( std::size_t nAuthor, RedlineType eType )
+void SwRedlineItr::FillHints( RedlineType eType )
 {
     switch ( eType )
     {

--- a/libreoffice-core/sw/source/core/text/redlnitr.cxx
+++ b/libreoffice-core/sw/source/core/text/redlnitr.cxx
@@ -871,14 +871,14 @@ void SwRedlineItr::FillHints( std::size_t nAuthor, RedlineType eType )
     switch ( eType )
     {
         case RedlineType::Insert:
-            SW_MOD()->GetInsertAuthorAttr(nAuthor, *m_pSet);
+            SW_MOD()->GetInsertAuthorAttr(*m_pSet);
             break;
         case RedlineType::Delete:
-            SW_MOD()->GetDeletedAuthorAttr(nAuthor, *m_pSet);
+            SW_MOD()->GetDeletedAuthorAttr(*m_pSet);
             break;
         case RedlineType::Format:
         case RedlineType::FmtColl:
-            SW_MOD()->GetFormatAuthorAttr(nAuthor, *m_pSet);
+            SW_MOD()->GetFormatAuthorAttr(*m_pSet);
             break;
         default:
             break;

--- a/libreoffice-core/sw/source/core/text/redlnitr.hxx
+++ b/libreoffice-core/sw/source/core/text/redlnitr.hxx
@@ -88,7 +88,7 @@ private:
 
     void Clear_( SwFont* pFnt );
     bool ChkSpecialUnderline_() const;
-    void FillHints( std::size_t nAuthor, RedlineType eType );
+    void FillHints( RedlineType eType );
     short EnterExtend(SwFont& rFnt, SwNodeOffset const nNode, sal_Int32 const nNew)
     {
         if (m_pExt) return m_pExt->Enter(rFnt, nNode, nNew);

--- a/libreoffice-core/sw/source/core/text/txtfld.cxx
+++ b/libreoffice-core/sw/source/core/text/txtfld.cxx
@@ -628,9 +628,9 @@ static bool lcl_setRedlineAttr( SwTextFormatInfo &rInf, const SwTextNode& rTextN
             : pRedlineNum->GetAuthor();
 
     if ( RedlineType::Delete == pRedlineNum->GetType() )
-        SW_MOD()->GetDeletedAuthorAttr(aAuthor, aSet);
+        SW_MOD()->GetDeletedAuthorAttr(aSet);
     else
-        SW_MOD()->GetInsertAuthorAttr(aAuthor, aSet);
+        SW_MOD()->GetInsertAuthorAttr(aSet);
 
     if (const SvxColorItem* pItem = aSet.GetItemIfSet(RES_CHRATR_COLOR))
         pNumFnt->SetColor(pItem->GetValue());

--- a/libreoffice-core/sw/source/core/text/txtfld.cxx
+++ b/libreoffice-core/sw/source/core/text/txtfld.cxx
@@ -623,10 +623,6 @@ static bool lcl_setRedlineAttr( SwTextFormatInfo &rInf, const SwTextNode& rTextN
     SwAttrPool& rPool = rInf.GetVsh()->GetDoc()->GetAttrPool();
     SfxItemSetFixed<RES_CHRATR_BEGIN, RES_CHRATR_END-1> aSet(rPool);
 
-    std::size_t aAuthor = (1 < pRedlineNum->GetStackCount())
-            ? pRedlineNum->GetAuthor( 1 )
-            : pRedlineNum->GetAuthor();
-
     if ( RedlineType::Delete == pRedlineNum->GetType() )
         SW_MOD()->GetDeletedAuthorAttr(aSet);
     else

--- a/libreoffice-core/sw/source/core/text/txtfld.cxx
+++ b/libreoffice-core/sw/source/core/text/txtfld.cxx
@@ -73,6 +73,22 @@ static bool lcl_IsInBody( SwFrame const *pFrame )
     }
 }
 
+static OUString redlineNumberBuilder(OUString aHiddenText)
+{
+    OUStringLiteral REDLINE_NUMBER_BUILDER_STRIKETHROUGH = u"\u0336";
+    sal_Int32 length = aHiddenText.getLength();
+    OUString result = "";
+
+    // Iterate through each character
+    for (int i = 0; i < length; i++)
+    {
+        result = result + OUString(aHiddenText[i])
+                 + REDLINE_NUMBER_BUILDER_STRIKETHROUGH;
+    }
+
+    return result;
+}
+
 SwExpandPortion *SwTextFormatter::NewFieldPortion( SwTextFormatInfo &rInf,
                                                 const SwTextAttr *pHint ) const
 {
@@ -757,30 +773,55 @@ SwNumberPortion *SwTextFormatter::NewNumberPortion( SwTextFormatInfo &rInf ) con
                 // (SwListRedlineType::SHOW, which counts removed and inserted numbered paragraphs
                 // in a single list)
                 bool bHasHiddenNum = false;
-                OUString aText( pTextNd->GetNumString(true, MAXLEVEL, m_pFrame->getRootFrame(), SwListRedlineType::HIDDEN) );
+                bool bColorBlack = false;
+                OUString aText(pTextNd->GetNumString(true, MAXLEVEL, m_pFrame->getRootFrame(),
+                                                     SwListRedlineType::HIDDEN));
                 const SwDoc& rDoc = pTextNd->GetDoc();
                 const SwRedlineTable& rTable = rDoc.getIDocumentRedlineAccess().GetRedlineTable();
-                if ( rTable.size() && !rInf.GetVsh()->GetLayout()->IsHideRedlines() )
+                if (rTable.size() && !rInf.GetVsh()->GetLayout()->IsHideRedlines())
                 {
-                    OUString aHiddenText( pTextNd->GetNumString(true, MAXLEVEL, m_pFrame->getRootFrame(), SwListRedlineType::ORIGTEXT) );
+                    OUString aHiddenText(pTextNd->GetNumString(
+                        true, MAXLEVEL, m_pFrame->getRootFrame(), SwListRedlineType::ORIGTEXT));
 
-                    if ( !aText.isEmpty() || !aHiddenText.isEmpty() )
+                    if (!aText.isEmpty() || !aHiddenText.isEmpty())
                     {
-                        if (aText != aHiddenText && !aHiddenText.isEmpty())
+                        // Case 1: aText is empty and aHiddenText is not empty
+                        // We want to have a standard number
+                        if (aText.isEmpty() && !aHiddenText.isEmpty())
+                        {
+                            aText = aHiddenText + pTextNd->GetLabelFollowedBy().replaceAll("\t", " ");
+                        }
+                        // Case 2: aText is not empty and aHiddenText is empty
+                        else if (!aText.isEmpty() && aHiddenText.isEmpty())
+                        {
+                            aText = aText + pTextNd->GetLabelFollowedBy().replaceAll("\t", " ");
+                        }
+                        // Case 3-4: aText && aHiddenText
+                        else if (!aText.isEmpty() && !aHiddenText.isEmpty())
                         {
                             bHasHiddenNum = true;
-                            // show also original number after the actual one enclosed in [ and ],
-                            // and replace tabulator with space to avoid messy indentation
-                            // resulted by the longer numbering, e.g. "1.[2.]" instead of "1.".
-                            aText = aText +  "[" + aHiddenText + "]"
-                                     + pTextNd->GetLabelFollowedBy().replaceAll("\t", " ");
+
+                            // Case 3: aText != aHiddenText
+                            if (aText != aHiddenText)
+                            {
+                                OUString aPreviousValue = redlineNumberBuilder(aHiddenText);
+                                aText = aPreviousValue + " " + aText
+                                    + pTextNd->GetLabelFollowedBy().replaceAll("\t", " ");
+                            }
+                            // Case 4: aText != aHiddenText
+                            else
+                            {
+                                bColorBlack = true;
+                                aText = aText + pTextNd->GetLabelFollowedBy().replaceAll("\t", " ");
+                            }
                         }
                         else if (!aText.isEmpty())
                             aText += pTextNd->GetLabelFollowedBy();
                     }
                 }
-                else if (pTextNd->getIDocumentSettingAccess()->get(DocumentSettingId::NO_NUMBERING_SHOW_FOLLOWBY)
-                    || !aText.isEmpty())
+                else if (pTextNd->getIDocumentSettingAccess()->get(
+                             DocumentSettingId::NO_NUMBERING_SHOW_FOLLOWBY)
+                         || !aText.isEmpty())
                     aText += pTextNd->GetLabelFollowedBy();
 
                 // Not just an optimization ...
@@ -832,8 +873,8 @@ SwNumberPortion *SwTextFormatter::NewNumberPortion( SwTextFormatInfo &rInf ) con
 
                     checkApplyParagraphMarkFormatToNumbering(pNumFnt.get(), rInf, pIDSA, pFormat);
 
-                    if ( !lcl_setRedlineAttr( rInf, *pTextNd, pNumFnt ) && bHasHiddenNum )
-                        pNumFnt->SetColor(NON_PRINTING_CHARACTER_COLOR);
+                    if ( !lcl_setRedlineAttr( rInf, *pTextNd, pNumFnt ) && bHasHiddenNum && !bColorBlack)
+                        pNumFnt->SetColor(COL_GREEN);
 
                     // we do not allow a vertical font
                     pNumFnt->SetVertical( pNumFnt->GetOrientation(), m_pFrame->IsVertical() );

--- a/libreoffice-core/sw/source/core/text/txtftn.cxx
+++ b/libreoffice-core/sw/source/core/text/txtftn.cxx
@@ -1010,10 +1010,6 @@ SwNumberPortion *SwTextFormatter::NewFootnoteNumPortion( SwTextFormatInfo const 
             SwAttrPool& rPool = pDoc->GetAttrPool();
             SfxItemSetFixed<RES_CHRATR_BEGIN, RES_CHRATR_END-1> aSet(rPool);
 
-            std::size_t aAuthor = (1 < pRedline->GetStackCount())
-                    ? pRedline->GetAuthor( 1 )
-                    : pRedline->GetAuthor();
-
             if ( RedlineType::Delete == pRedline->GetType() )
                 SW_MOD()->GetDeletedAuthorAttr(aSet);
             else

--- a/libreoffice-core/sw/source/core/text/txtftn.cxx
+++ b/libreoffice-core/sw/source/core/text/txtftn.cxx
@@ -1015,9 +1015,9 @@ SwNumberPortion *SwTextFormatter::NewFootnoteNumPortion( SwTextFormatInfo const 
                     : pRedline->GetAuthor();
 
             if ( RedlineType::Delete == pRedline->GetType() )
-                SW_MOD()->GetDeletedAuthorAttr(aAuthor, aSet);
+                SW_MOD()->GetDeletedAuthorAttr(aSet);
             else
-                SW_MOD()->GetInsertAuthorAttr(aAuthor, aSet);
+                SW_MOD()->GetInsertAuthorAttr(aSet);
 
             if (const SvxColorItem* pItem = aSet.GetItemIfSet(RES_CHRATR_COLOR))
                 pNumFnt->SetColor(pItem->GetValue());

--- a/libreoffice-core/sw/source/uibase/app/swmodul1.cxx
+++ b/libreoffice-core/sw/source/uibase/app/swmodul1.cxx
@@ -508,12 +508,12 @@ static void lcl_FillAuthorAttr( Color aCol, SfxItemSet &rSet, const AuthorCharAt
 
 void SwModule::GetInsertAuthorAttr(SfxItemSet &rSet)
 {
-    lcl_FillAuthorAttr( COL_BLUE, rSet, m_pModuleConfig->GetInsertAuthorAttr());
+    lcl_FillAuthorAttr( COL_BLUE_CLASSIC, rSet, m_pModuleConfig->GetInsertAuthorAttr());
 }
 
 void SwModule::GetDeletedAuthorAttr(SfxItemSet &rSet)
 {
-    lcl_FillAuthorAttr( COL_RED, rSet, m_pModuleConfig->GetDeletedAuthorAttr());
+    lcl_FillAuthorAttr( COL_RED_CLASSIC, rSet, m_pModuleConfig->GetDeletedAuthorAttr());
 }
 
 // For future extension:

--- a/libreoffice-core/sw/source/uibase/app/swmodul1.cxx
+++ b/libreoffice-core/sw/source/uibase/app/swmodul1.cxx
@@ -428,6 +428,18 @@ void SwModule::ClearRedlineAuthors()
     m_pAuthorNames.clear();
 }
 
+static Color lcl_GetAuthorColor(std::size_t nPos)
+{
+    static const Color aColArr[] =
+    {
+        COL_AUTHOR1_DARK, COL_AUTHOR2_DARK, COL_AUTHOR3_DARK,
+        COL_AUTHOR4_DARK, COL_AUTHOR5_DARK, COL_AUTHOR6_DARK,
+        COL_AUTHOR7_DARK, COL_AUTHOR8_DARK, COL_AUTHOR9_DARK
+    };
+
+    return aColArr[nPos % SAL_N_ELEMENTS(aColArr)];
+}
+
 /// Returns a JSON representation of a redline author.
 void SwModule::GetRedlineAuthorInfo(tools::JsonWriter& rJsonWriter)
 {

--- a/libreoffice-core/sw/source/uibase/app/swmodul1.cxx
+++ b/libreoffice-core/sw/source/uibase/app/swmodul1.cxx
@@ -428,18 +428,6 @@ void SwModule::ClearRedlineAuthors()
     m_pAuthorNames.clear();
 }
 
-static Color lcl_GetAuthorColor(std::size_t nPos)
-{
-    static const Color aColArr[] =
-    {
-        COL_AUTHOR1_DARK, COL_AUTHOR2_DARK, COL_AUTHOR3_DARK,
-        COL_AUTHOR4_DARK, COL_AUTHOR5_DARK, COL_AUTHOR6_DARK,
-        COL_AUTHOR7_DARK, COL_AUTHOR8_DARK, COL_AUTHOR9_DARK
-    };
-
-    return aColArr[nPos % SAL_N_ELEMENTS(aColArr)];
-}
-
 /// Returns a JSON representation of a redline author.
 void SwModule::GetRedlineAuthorInfo(tools::JsonWriter& rJsonWriter)
 {
@@ -449,7 +437,6 @@ void SwModule::GetRedlineAuthorInfo(tools::JsonWriter& rJsonWriter)
         auto authorNode = rJsonWriter.startStruct();
         rJsonWriter.put("index", static_cast<sal_Int64>(nAuthor));
         rJsonWriter.put("name", m_pAuthorNames[nAuthor]);
-        rJsonWriter.put("color", sal_uInt32(lcl_GetAuthorColor(nAuthor)));
     }
 }
 

--- a/libreoffice-core/sw/source/uibase/app/swmodul1.cxx
+++ b/libreoffice-core/sw/source/uibase/app/swmodul1.cxx
@@ -466,15 +466,9 @@ std::size_t SwModule::InsertRedlineAuthor(const OUString& rAuthor)
     return nPos;
 }
 
-static void lcl_FillAuthorAttr( std::size_t nAuthor, SfxItemSet &rSet,
-                        const AuthorCharAttr &rAttr )
+static void lcl_FillAuthorAttr( Color aCol, SfxItemSet &rSet, const AuthorCharAttr &rAttr )
 {
-    Color aCol( rAttr.m_nColor );
-
-    if( rAttr.m_nColor == COL_TRANSPARENT )
-        aCol = lcl_GetAuthorColor(nAuthor);
-
-    bool bBackGr = rAttr.m_nColor == COL_NONE_COLOR;
+    bool bBackGr = aCol == COL_NONE_COLOR || rAttr.m_nColor == COL_NONE_COLOR;
 
     switch (rAttr.m_nItemId)
     {
@@ -525,20 +519,20 @@ static void lcl_FillAuthorAttr( std::size_t nAuthor, SfxItemSet &rSet,
         rSet.Put( SvxColorItem( aCol, RES_CHRATR_COLOR ) );
 }
 
-void SwModule::GetInsertAuthorAttr(std::size_t nAuthor, SfxItemSet &rSet)
+void SwModule::GetInsertAuthorAttr(SfxItemSet &rSet)
 {
-    lcl_FillAuthorAttr(nAuthor, rSet, m_pModuleConfig->GetInsertAuthorAttr());
+    lcl_FillAuthorAttr( COL_BLUE, rSet, m_pModuleConfig->GetInsertAuthorAttr());
 }
 
-void SwModule::GetDeletedAuthorAttr(std::size_t nAuthor, SfxItemSet &rSet)
+void SwModule::GetDeletedAuthorAttr(SfxItemSet &rSet)
 {
-    lcl_FillAuthorAttr(nAuthor, rSet, m_pModuleConfig->GetDeletedAuthorAttr());
+    lcl_FillAuthorAttr( COL_RED, rSet, m_pModuleConfig->GetDeletedAuthorAttr());
 }
 
 // For future extension:
-void SwModule::GetFormatAuthorAttr( std::size_t nAuthor, SfxItemSet &rSet )
+void SwModule::GetFormatAuthorAttr(SfxItemSet &rSet )
 {
-    lcl_FillAuthorAttr( nAuthor, rSet, m_pModuleConfig->GetFormatAuthorAttr() );
+    lcl_FillAuthorAttr( COL_NONE_COLOR, rSet, m_pModuleConfig->GetFormatAuthorAttr() );
 }
 
 sal_uInt16 SwModule::GetRedlineMarkPos() const


### PR DESCRIPTION
- Adds redlining changes such that strikethroughs are colored red and additions are blue
- Formatting differences are left unchanged
- Update numbering to match falcon lok comparison number list formatting before: 2.2[2.1] after:(2.1→2.2)

***Examples***

Consolidate comparison with Christy NDA:
Before:
![CleanShot 2023-09-18 at 17 34 59](https://github.com/coparse-inc/libreofficekit/assets/25272206/56c43e9e-333b-4e70-b1b6-b64dc4ed82b7)
After:
![CleanShot 2023-09-18 at 18 18 26](https://github.com/coparse-inc/libreofficekit/assets/25272206/be26bedf-5d3f-4517-bdf1-0e253d749df6)

Regular `A_Agreement.docx` <--> `B_Agreement.docx` 1:1 comparison:
![CleanShot 2023-09-18 at 18 19 18](https://github.com/coparse-inc/libreofficekit/assets/25272206/e4a2ec9e-a48e-43b4-83a2-ba341d9527d2)

Formatting differences are left unchanged (except for additions which are blue):
![CleanShot 2023-09-18 at 18 22 19](https://github.com/coparse-inc/libreofficekit/assets/25272206/3b0d81e3-c46a-4518-8a80-9a41fc18c34c)