### PR TITLE
Allow building on other branches than main in CI

### DIFF
--- a/.github/workflows/check-version-tag.yml
+++ b/.github/workflows/check-version-tag.yml
@@ -20,9 +20,9 @@ jobs:
     steps:
       - id: check_version
         continue-on-error: true
-        name: check latest commit is less than a day
+        name: check latest commit version is tagged
         run: |
-          git clone --no-checkout --depth=1 --sparse --filter=blob:none https://github.com/${{ github.repository }} lok
+          git clone --no-checkout --depth=1 --sparse --filter=blob:none --branch=${{github.ref_name}} --single-branch https://github.com/${{ github.repository }} lok
           cd lok
           git checkout
           echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -20,7 +20,7 @@ jobs:
           git config --global core.eol lf
       - name: Sparse Checkout
         run: |
-          git clone --no-checkout --depth=1 --filter=blob:none --sparse https://github.com/${{ github.repository }} lok
+          git clone --no-checkout --depth=1 --filter=blob:none --branch=${{ github.ref_name }} --single-branch --sparse https://github.com/${{ github.repository }} lok
           cd lok
           git config --local gc.auto 0
           tee .git/info/sparse-checkout <<EOF
@@ -87,7 +87,7 @@ jobs:
           UID_GID="$(id -u):$(id -g)"
           sudo mkdir /lok
           sudo chown $UID_GID /lok
-          git -c protocol.version=2 clone --depth=1 https://github.com/${{ github.repository }} /lok
+          git -c protocol.version=2 clone --depth=1 --branch=${{github.ref_name}} --single-branch https://github.com/${{ github.repository }} /lok
           cd /lok
           git config --local gc.auto 0
       - name: Install build dependencies

--- a/.github/workflows/release-win.yml
+++ b/.github/workflows/release-win.yml
@@ -20,7 +20,7 @@ jobs:
           git config --global core.eol lf
       - name: Sparse Checkout
         run: |
-          git clone --no-checkout --depth=1 --filter=blob:none --sparse https://github.com/${{ github.repository }} lok
+          git clone --no-checkout --depth=1 --filter=blob:none --sparse --branch=${{ github.ref_name }} --single-branch https://github.com/${{ github.repository }} lok
           cd lok
           git config --local gc.auto 0
           tee .git/info/sparse-checkout <<EOF
@@ -92,7 +92,7 @@ jobs:
           git config --global core.eol lf
       - name: Checkout
         run: |
-          git -c protocol.version=2 clone --depth=1 https://github.com/${{ github.repository }} /c/lok
+          git -c protocol.version=2 clone --depth=1 --branch=${{github.ref_name}} --single-branch https://github.com/${{ github.repository }} /c/lok
           cd /c/lok
           git config --local gc.auto 0
         shell: bash


### PR DESCRIPTION
This way by adding another branch to a workflow, a PR can try a build and release without requiring an `urgent` label and merge to `main`