### PR TITLE
Fix saveToMemory crash when pFormat not set

### DIFF
--- a/libreoffice-core/include/LibreOfficeKit/LibreOfficeKit.hxx
+++ b/libreoffice-core/include/LibreOfficeKit/LibreOfficeKit.hxx
@@ -509,7 +509,7 @@ public:
      * @param pOutput the data of the file
      * @return size_t the size of the data
     */
-    size_t saveToMemory(char** pOutput, void *(*chrome_malloc)(size_t size), const char* pFormat)
+    size_t saveToMemory(char** pOutput, void *(*chrome_malloc)(size_t size), const char* pFormat = nullptr)
     {
         return mpDoc->pClass->saveToMemory(mpDoc,pOutput,chrome_malloc, pFormat);
     }


### PR DESCRIPTION
Seems like per Chase's earlier [PR](https://github.com/coparse-inc/libreofficekit/pull/77/files) this should be an optional requirement, but I was getting a crash when using ELOK. Assuming we want to keep it optional here is a quick fix that I've tested works with ELOK.

What I was getting before:
```
../../electron/office/document_client.cc:399:57: error: too few arguments to function call, expected 3, have 2
  size_t size = document_->saveToMemory(&pOutput, malloc);
                ~~~~~~~~~~~~~~~~~~~~~~~                 ^
../../third_party/libreofficekit/instdir/aarch64/sdk/include/LibreOfficeKit/LibreOfficeKit.hxx:512:12: note: 'saveToMemory' declared here
    size_t saveToMemory(char** pOutput, void *(*chrome_malloc)(size_t size), const char* pFormat)
           ^
```