### PR TITLE
Fix 'zxx.UTF-8' encoding crash

### DIFF
--- a/libreoffice-core/comphelper/source/misc/lok.cxx
+++ b/libreoffice-core/comphelper/source/misc/lok.cxx
@@ -47,8 +47,8 @@ private:
 public:
 
     LanguageAndLocale()
-        : maLanguageTag(LANGUAGE_NONE)
-        , maLocaleLanguageTag(LANGUAGE_NONE)
+        : maLanguageTag("en-US")
+        , maLocaleLanguageTag("en-US")
     {}
 
     const LanguageTag& getLanguage() const


### PR DESCRIPTION
The default elsewhere is "en-US", this should fix an occasional crash when loading documents