### PR TITLE
FIX remove ViewShell check, fix colorizer event emitted

### DIFF
--- a/libreoffice-core/sw/source/uibase/uno/colorizer.cxx
+++ b/libreoffice-core/sw/source/uibase/uno/colorizer.cxx
@@ -74,16 +74,9 @@ void emitCallback(rtl::Reference<SwXTextDocument> doc, LibreOfficeKitCallbackTyp
         return;
     }
 
-    // MACRO-1384: prevent crash on load for some comment edgecases
-    SwView* pCurView = dynamic_cast<SwView*>(SfxViewShell::Current());
-    if (!pCurView)
-    {
-        return;
-    }
-
     SwDocShell* pDocSh = doc->GetDocShell();
     SwView* pView = pDocSh->GetView();
-    if (!pView || pView != pCurView)
+    if (!pView)
     {
         return;
     }


### PR DESCRIPTION
SwView* pCurView = dynamic_cast<SwView*>(SfxViewShell::Current()), wouldn't return a view shell thus even though the colorizer finished, the event was never emitted and it would seem as if it was running indefinitely.
