### PR TITLE
No bold in LOK changed attribute

### DIFF
--- a/libreoffice-core/officecfg/registry/schema/org/openoffice/Office/Writer.xcs
+++ b/libreoffice-core/officecfg/registry/schema/org/openoffice/Office/Writer.xcs
@@ -2526,7 +2526,7 @@
                 </info>
               </enumeration>
             </constraints>
-            <value>1</value>
+            <value>0</value>
           </prop>
           <prop oor:name="Color" oor:type="xs:int" oor:nillable="false">
             <!-- UIHints: Tools - Options - Text document - Changes - [Section] Text display -->


### PR DESCRIPTION
TODO: remove CI step when this gets in

Make it such that track changes formatting changes will not bold the text by default in LOK