### PR TITLE
Passive Google Fonts

### DIFF
--- a/libreoffice-core/include/vcl/outdev.hxx
+++ b/libreoffice-core/include/vcl/outdev.hxx
@@ -1157,9 +1157,6 @@ public:
                                                    AddFontSubstituteFlags nFlags );
     static void                 RemoveFontsSubstitute();
 
-    // MACRO-1518: Fix Calibri and Cambria display
-    static void                 AddCustomMacroFonts();
-
     static vcl::Font            GetDefaultFont( DefaultFontType nType,
                                                 LanguageType eLang,
                                                 GetDefaultFontFlags nFlags,
@@ -1167,7 +1164,6 @@ public:
 
     SAL_DLLPRIVATE void         ImplInitFontList() const;
     SAL_DLLPRIVATE void         ImplUpdateFontData();
-    SAL_DLLPRIVATE void         ImplAddCustomMacroFonts();
 
     //drop font data for all outputdevices.
     //If bNewFontLists is true then empty lists of system fonts

--- a/libreoffice-core/svtools/source/config/fontsubstconfig.cxx
+++ b/libreoffice-core/svtools/source/config/fontsubstconfig.cxx
@@ -57,10 +57,6 @@ bool IsFontSubstitutionsEnabled()
 
 std::vector<SubstitutionStruct> GetFontSubstitutions()
 {
-    // This will load in the custom .ttf metric-compatible fonts.
-    // Do not remove; this gets executed once here.
-    OutputDevice::AddCustomMacroFonts();
-
     Reference<css::container::XHierarchicalNameAccess> xHierarchyAccess = utl::ConfigManager::acquireTree(u"Office.Common/Font/Substitution");
 
     const Sequence<OUString> aNodeNames = utl::ConfigItem::GetNodeNames(xHierarchyAccess, cFontPairs, utl::ConfigNameFormat::LocalPath);

--- a/libreoffice-core/vcl/source/outdev/font.cxx
+++ b/libreoffice-core/vcl/source/outdev/font.cxx
@@ -49,10 +49,6 @@
 #include <salgdi.hxx>
 #include <svdata.hxx>
 
-#include <unx/helper.hxx>
-#include <config_folders.h>
-#include "rtl/bootstrap.hxx"
-
 #include <unicode/uchar.h>
 
 #include <strings.hrc>
@@ -387,40 +383,6 @@ void OutputDevice::BeginFontSubstitution()
     ImplSVData* pSVData = ImplGetSVData();
     pSVData->maGDIData.mbFontSubChanged = false;
 }
-
-// MACRO-1518: Fix Calibri and Cambria display {
-void OutputDevice::AddCustomMacroFonts()
-{
-    OutputDevice* pDevice = Application::GetDefaultDevice();
-    pDevice->ImplAddCustomMacroFonts();
-}
-
-void OutputDevice::ImplAddCustomMacroFonts()
-{
-    static constexpr std::u16string_view carlitoFontNames[] = {
-        u"Carlito",
-        u"Carlito-Bold",
-        u"Carlito-Italic",
-        u"Carlito-BoldItalic",
-    };
-    static constexpr std::u16string_view caladeaFontNames[] = {
-        u"Caladea",
-        u"Caladea-Bold",
-        u"Caladea-Italic",
-        u"Caladea-BoldItalic"
-    };
-
-    OUString basePath("$BRAND_BASE_DIR/" LIBO_SHARE_RESOURCE_FOLDER "/macro_fonts/");
-    rtl::Bootstrap::expandMacros(basePath);
-
-    for (auto& name : carlitoFontNames) {
-        OutputDevice::AddTempDevFont(basePath + name + u".ttf", u"Carlito");
-    }
-    for (auto& name : caladeaFontNames) {
-        OutputDevice::AddTempDevFont(basePath + name + u".ttf", u"Caladea");
-    }
-}
-// } MACRO-1518: Fix Calibri and Cambria display
 
 void OutputDevice::EndFontSubstitution()
 {

--- a/libreoffice-core/vcl/unx/generic/fontmanager/helper.cxx
+++ b/libreoffice-core/vcl/unx/generic/fontmanager/helper.cxx
@@ -195,6 +195,8 @@ OUString const & psp::getFontPath()
             // internal font resources, required for normal operation, like OpenSymbol
             aPathBuffer.append(aInstallationRootPath
                                + "/" LIBO_SHARE_RESOURCE_FOLDER "/common/fonts;");
+            aPathBuffer.append(aInstallationRootPath
+                               + "/" LIBO_SHARE_RESOURCE_FOLDER "/macro_fonts;");
         }
         if( !aConfigPath.isEmpty() )
         {


### PR DESCRIPTION
@awallace I had a brief recollection of how the Open Symbol font was getting loaded, then I realized we could use the font manager instead of actively loading the font. This should be a speed up in general, but especially for documents that don't use the replaced fonts. This builds on top of your PR.

[Lorem ipsum dolor sit amet.docx](https://github.com/coparse-inc/libreofficekit/files/13407947/Lorem.ipsum.dolor.sit.amet.docx)

Before:
<img width="1311" alt="image" src="https://github.com/coparse-inc/libreofficekit/assets/5411/1570a8d6-b2bf-4c59-b79e-ea036304d8aa">

After:
<img width="1276" alt="image" src="https://github.com/coparse-inc/libreofficekit/assets/5411/2060a4a6-c76d-4e02-95d6-2677ee9a8a69">

And on Windows (ignore the weird non-transparent background on Windows):
![image](https://github.com/coparse-inc/libreofficekit/assets/5411/b367adce-de0f-4022-8193-171c5e694a16)
