### PR TITLE
CHG don't init widgets on scroll? [MACRO-1802]

### DIFF
--- a/libreoffice-core/vcl/Module_vcl.mk
+++ b/libreoffice-core/vcl/Module_vcl.mk
@@ -27,7 +27,6 @@ endif
 
 $(eval $(call gb_Module_add_targets,vcl,\
     Library_vcl \
-    Package_theme_definitions \
     Package_toolbarmode \
     UIConfig_vcl \
     $(if $(filter WNT,$(OS)), \

--- a/libreoffice-core/vcl/headless/svpgdi.cxx
+++ b/libreoffice-core/vcl/headless/svpgdi.cxx
@@ -29,8 +29,11 @@ SvpSalGraphics::SvpSalGraphics()
     : m_aTextRenderImpl(*this)
     , m_pBackend(new SvpGraphicsBackend(m_aCairoCommon))
 {
-    bool bLOKActive = comphelper::LibreOfficeKit::isActive();
-    initWidgetDrawBackends(bLOKActive);
+    //MACRO-1802: expensive, effectively dead code removed
+    /**
+     * initWidgetDrawBackends instantiated FileDefinitionWidgetDraw which
+     * repeatedly fails to load a theme that hasn't existed for 4+ years.
+     */
 }
 
 SvpSalGraphics::~SvpSalGraphics()


### PR DESCRIPTION
While profiling I noticed that we are spending a significant amount of time, trying to initialize some kind of widget.
<img width="728" alt="CleanShot 2023-11-20 at 17 30 48@2x" src="https://github.com/coparse-inc/libreofficekit/assets/10552019/5da42e31-115b-4b48-9515-7686e7eaba0f">



I tried to do some digging around and it seems like these widgets might be like graphical widgets. Since it is referring to Aqua in some places (macos gtk equivelent ?).

Disabling the initialization of these widget draw backends made the performance of scrolling MUCH better.

https://github.com/coparse-inc/libreofficekit/assets/10552019/a2673962-7aab-4608-9988-b1861fd36006


