### PR TITLE
FIX nested deletion tc grouping [MACRO-1723]

### DIFF
--- a/libreoffice-core/sw/source/core/doc/DocumentRedlineManager.cxx
+++ b/libreoffice-core/sw/source/core/doc/DocumentRedlineManager.cxx
@@ -1907,7 +1907,9 @@ DocumentRedlineManager::AppendRedline(SwRangeRedline* pNewRedl, bool const bCall
                                 // redline w/out extent loops
                                 if (*pStt != *pEnd)
                                 {
-                                    pNewRedl->PushData( *pRedl, false );
+
+                                    // NOTE: MACRO-1723
+                                    /* pNewRedl->PushData( *pRedl, false ); */
                                     pRedl->SetStart( *pEnd, pRStt );
                                     // re-insert
                                     maRedlineTable.Remove( n );
@@ -1917,7 +1919,8 @@ DocumentRedlineManager::AppendRedline(SwRangeRedline* pNewRedl, bool const bCall
                             }
                             else
                             {
-                                pNewRedl->PushData( *pRedl, false );
+                                // NOTE: [MACRO-1723]
+                                /* pNewRedl->PushData( *pRedl, false ); */
                                 if( *pREnd != *pEnd )
                                 {
                                     pNew = new SwRangeRedline( *pRedl );


### PR DESCRIPTION
Fixes grouping when deleting within a nested track change from another author.

Previously, if there was a nested deletion within the track changes, it would divide the track changes. However, it would also transfer the author's information from the first track change to all three, resulting in all of them displaying the first author.


ignore buggy tc-scroll will fix (fix already in master, just didnt re-record video)



