### PR TITLE
Fix OOB crash when using gotoOutline

### DIFF
--- a/libreoffice-core/desktop/source/lib/init.cxx
+++ b/libreoffice-core/desktop/source/lib/init.cxx
@@ -6870,9 +6870,10 @@ static char* doc_gotoOutline(LibreOfficeKitDocument* pThis, int idx)
 
     tools::JsonWriter aJsonWriter;
 
-    pDoc->gotoOutline(aJsonWriter, idx);
-
-    return aJsonWriter.extractData();
+    if (pDoc->gotoOutline(aJsonWriter, idx))
+        return aJsonWriter.extractData();
+    else
+        return nullptr;
 }
 
 static size_t doc_saveToMemory(LibreOfficeKitDocument* pThis, char** pOutput, void *(*chrome_malloc)(size_t size), const char* pFormat)

--- a/libreoffice-core/include/LibreOfficeKit/LibreOfficeKit.hxx
+++ b/libreoffice-core/include/LibreOfficeKit/LibreOfficeKit.hxx
@@ -497,7 +497,7 @@ public:
     /**
      * Forces your cursor to a given outline
      * @param idx the id of the outline you want to navigate to
-     * @return {destRect: ""} The rect of the outline
+     * @return null | {destRect: ""} The rect of the outline if the index is valid, null otherwise
     */
     char* gotoOutline(int idx)
     {

--- a/libreoffice-core/include/vcl/ITiledRenderable.hxx
+++ b/libreoffice-core/include/vcl/ITiledRenderable.hxx
@@ -386,8 +386,9 @@ public:
     }
 
     /// Used to force the cursor to given element in the document outline
-    virtual void gotoOutline(tools::JsonWriter& /*rJsonWriter*/, int /*idx*/)
+    virtual bool gotoOutline(tools::JsonWriter& /*rJsonWriter*/, int /*idx*/)
     {
+        return false;
     }
 
     /// Used to create tables

--- a/libreoffice-core/sw/inc/unotxdoc.hxx
+++ b/libreoffice-core/sw/inc/unotxdoc.hxx
@@ -474,7 +474,7 @@ public:
     bool supportsCommand(std::u16string_view rCommand) override;
 
     /// @see vcl::ITiledRenderable::gotoOutline().
-    void gotoOutline(tools::JsonWriter& rJsonWriter, int idx) override;
+    bool gotoOutline(tools::JsonWriter& rJsonWriter, int idx) override;
 
     /// @see vcl::ITiledRenderable::createTable().
     void createTable(int row, int col) override;

--- a/libreoffice-core/sw/source/uibase/uno/loktxdoc.cxx
+++ b/libreoffice-core/sw/source/uibase/uno/loktxdoc.cxx
@@ -574,15 +574,18 @@ void SwXTextDocument::getCommandValues(tools::JsonWriter& rJsonWriter, std::stri
     }
 }
 
-void SwXTextDocument::gotoOutline(tools::JsonWriter& rJsonWriter, int idx)
+bool SwXTextDocument::gotoOutline(tools::JsonWriter& rJsonWriter, int idx)
 {
     SwWrtShell* mrSh = m_pDocShell->GetWrtShell();
 
+    if (idx < 0) return false;
+    if ((size_t)idx >= m_pDocShell->GetDoc()->GetNodes().GetOutLineNds().size()) return false;
     mrSh->GotoOutline(idx);
 
     SwRect destRect = mrSh->GetCharRect();
 
     rJsonWriter.put("destRect", destRect.SVRect().toString());
+    return true;
 }
 
 void SwXTextDocument::createTable(int row, int col)


### PR DESCRIPTION
# Summary of PR
This prevents out-of-bounds crashes that can occur with gotoOutline 

## Before you submit this PR
This is a **public, open source project**. Confidential or sensitive information should not be included in this description or any comments, including but not limited to links, files, and documents.

*If you're not certain that information is not confidential or sensitive in nature, do not include it.*

- [X] I have verified that this PR does not include any confidential information
