### PR TITLE
Do not mutate text when reference is not found [MACRO-1718]

### DIFF
--- a/libreoffice-core/sw/source/core/fields/reffld.cxx
+++ b/libreoffice-core/sw/source/core/fields/reffld.cxx
@@ -523,8 +523,6 @@ void SwGetRefField::UpdateField(const SwTextField* pFieldTextAttr, SwFrame* pFra
 {
     SwDoc& rDoc = static_cast<SwGetRefFieldType*>(GetTyp())->GetDoc();
 
-    rText.clear();
-
     // finding the reference target (the number)
     sal_Int32 nNumStart = -1;
     sal_Int32 nNumEnd = -1;
@@ -535,10 +533,14 @@ void SwGetRefField::UpdateField(const SwTextField* pFieldTextAttr, SwFrame* pFra
     // not found?
     if ( !pTextNd )
     {
-        rText = SwViewShell::GetShellRes()->aGetRefField_RefItemNotFound;
+        // LibreOffice would update the referenced text to "Error: Reference source not found"
+        // when the source is, well, not found, e.g source got deleted
+        // rText = SwViewShell::GetShellRes()->aGetRefField_RefItemNotFound;
 
         return;
     }
+
+    rText.clear();
 
     // where is the category name (e.g. "Illustration")?
     const OUString aText = pTextNd->GetText();

--- a/libreoffice-core/sw/source/core/fields/reffld.cxx
+++ b/libreoffice-core/sw/source/core/fields/reffld.cxx
@@ -533,6 +533,7 @@ void SwGetRefField::UpdateField(const SwTextField* pFieldTextAttr, SwFrame* pFra
     // not found?
     if ( !pTextNd )
     {
+        // https://www.notion.so/macrocom/NoReferenceError-in-Document-text-for-invalid-references-03bf8156aec3427a8b974d2545e63041
         // LibreOffice would update the referenced text to "Error: Reference source not found"
         // when the source is, well, not found, e.g source got deleted
         // rText = SwViewShell::GetShellRes()->aGetRefField_RefItemNotFound;


### PR DESCRIPTION
# Summary of PR
<!-- Write a brief summary of what this PR achieves and if it is large, please outline the most important things to review -->
If a reference is not found, leave the original text alone. It shouldn't clear the text prematurely until the reference source is located and the text can be updated accordingly.

## Before you submit this PR
This is a **public, open source project**. Confidential or sensitive information should not be included in this description or any comments, including but not limited to links, files, and documents.

*If you're not certain that information is not confidential or sensitive in nature, do not include it.*

- [ ] I have verified that this PR does not include any confidential information
