### PR TITLE
CHG open readonly documents [MACRO-2259]

### DIFF
--- a/libreoffice-core/desktop/source/lib/init.cxx
+++ b/libreoffice-core/desktop/source/lib/init.cxx
@@ -2957,19 +2957,16 @@ static LibreOfficeKitDocument* lo_documentLoadWithOptions(LibreOfficeKit* pThis,
         }
 
         SfxBaseModel* pBaseModel = dynamic_cast<SfxBaseModel*>(pDocument->mxComponent.get());
-        if (!pBaseModel)
-            return nullptr;
-
-        SfxObjectShell* pObjectShell = pBaseModel->GetObjectShell();
-        if (!pObjectShell)
-            return nullptr;
-
-        // [MACRO-2259] We don't respect the readonly flag.
-        // If the document is readonly, we need to set it to false.
-        if (pObjectShell->IsLoadReadonly()) {
-            pObjectShell->SetReadOnlyUI(false);
+        if (pBaseModel != nullptr) {
+            SfxObjectShell* pObjectShell = pBaseModel->GetObjectShell();
+            if (pObjectShell != nullptr) {
+                // [MACRO-2259] We don't respect the readonly flag.
+                // If the document is readonly, we need to set it to false.
+                if (pObjectShell->IsLoadReadonly()) {
+                    pObjectShell->SetReadOnlyUI(false);
+                }
+            }
         }
-
 
         return pDocument;
     }

--- a/libreoffice-core/desktop/source/lib/init.cxx
+++ b/libreoffice-core/desktop/source/lib/init.cxx
@@ -2956,6 +2956,21 @@ static LibreOfficeKitDocument* lo_documentLoadWithOptions(LibreOfficeKit* pThis,
             pDocument->maFontsMissing.insert(aFontMappingUseData[i].mOriginalFont);
         }
 
+        SfxBaseModel* pBaseModel = dynamic_cast<SfxBaseModel*>(pDocument->mxComponent.get());
+        if (!pBaseModel)
+            return nullptr;
+
+        SfxObjectShell* pObjectShell = pBaseModel->GetObjectShell();
+        if (!pObjectShell)
+            return nullptr;
+
+        // [MACRO-2259] We don't respect the readonly flag.
+        // If the document is readonly, we need to set it to false.
+        if (pObjectShell->IsLoadReadonly()) {
+            pObjectShell->SetReadOnlyUI(false);
+        }
+
+
         return pDocument;
     }
     catch (const uno::Exception& exception)
@@ -6298,6 +6313,7 @@ static char* getDocReadOnly(LibreOfficeKitDocument* pThis)
     SfxObjectShell* pObjectShell = pBaseModel->GetObjectShell();
     if (!pObjectShell)
         return nullptr;
+
 
     boost::property_tree::ptree aTree;
     aTree.put("commandName", ".uno:ReadOnly");

--- a/libreoffice-core/desktop/source/lib/init.cxx
+++ b/libreoffice-core/desktop/source/lib/init.cxx
@@ -2956,12 +2956,12 @@ static LibreOfficeKitDocument* lo_documentLoadWithOptions(LibreOfficeKit* pThis,
             pDocument->maFontsMissing.insert(aFontMappingUseData[i].mOriginalFont);
         }
 
+        // [MACRO-2259] We don't respect the readonly flag.
+        // If the document is loaded readonly, we need to set it to false.
         SfxBaseModel* pBaseModel = dynamic_cast<SfxBaseModel*>(pDocument->mxComponent.get());
         if (pBaseModel != nullptr) {
             SfxObjectShell* pObjectShell = pBaseModel->GetObjectShell();
             if (pObjectShell != nullptr) {
-                // [MACRO-2259] We don't respect the readonly flag.
-                // If the document is readonly, we need to set it to false.
                 if (pObjectShell->IsLoadReadonly()) {
                     pObjectShell->SetReadOnlyUI(false);
                 }


### PR DESCRIPTION
# Summary of PR
If a document is loaded in readonly mode, we unset the readonly flag and allow interacting with it normally.

Document crashed, because you cannot dispatch certain commands when we are in readonly mode. We made the decision to not respect the readonly mode and load the document normally.

Confirmed on the document provided in the ticket that this indeed fixes issues with loading the document and allows for interaction as usually.

## Before you submit this PR
This is a **public, open source project**. Confidential or sensitive information should not be included in this description or any comments, including but not limited to links, files, and documents.

*If you're not certain that information is not confidential or sensitive in nature, do not include it.*

- [x] I have verified that this PR does not include any confidential information
