### PR TITLE
ADD getCommandValues .uno:CursorPosition [MACRO-1928]

### DIFF
--- a/libreoffice-core/desktop/source/lib/init.cxx
+++ b/libreoffice-core/desktop/source/lib/init.cxx
@@ -5884,6 +5884,16 @@ static char* getPageColor()
     return leakyStrDup(defaultColorHex);
 }
 
+static char* getCursorPosition()
+{
+    tools::JsonWriter aJson;
+    SfxViewShell* pViewShell = SfxViewShell::Current();
+    const int nViewId = sal_Int32(pViewShell->GetViewShellId());
+    std::optional<OString> payload = pViewShell->getLOKPayload(LOK_CALLBACK_INVALIDATE_VISIBLE_CURSOR, nViewId);
+    aJson.put("rect", payload.value_or(OString()));
+    return aJson.extractData();;
+}
+
 
 static char* getPageSize()
 {
@@ -6702,6 +6712,10 @@ static char* doc_getCommandValues(LibreOfficeKitDocument* pThis, const char* pCo
     if (!strcmp(pCommand, ".uno:PageColor"))
     {
         return getPageColor();
+    }
+    else if (!strcmp(pCommand, ".uno:CursorPosition"))
+    {
+        return getCursorPosition();
     }
     else if (!strcmp(pCommand, ".uno:PageSize"))
     {


### PR DESCRIPTION
# Summary of PR
Seems like focusing the embed is no longer sufficient to emit a cursor invalidation with a position.
This exposes a getCommandValue, that will return the current cursor position.
This is meant to be called right after document load to request a cursor position if we don't have one to render the cursor.

## Before you submit this PR
This is a **public, open source project**. Confidential or sensitive information should not be included in this description or any comments, including but not limited to links, files, and documents.

*If you're not certain that information is not confidential or sensitive in nature, do not include it.*

- [ ] I have verified that this PR does not include any confidential information
