### PR TITLE
FIX tc deletion inside insertion [MACRO-1723]

### DIFF
--- a/libreoffice-core/sw/inc/redline.hxx
+++ b/libreoffice-core/sw/inc/redline.hxx
@@ -126,6 +126,7 @@ public:
     RedlineType GetType() const { return m_eType; }
 
     std::size_t GetAuthor() const                { return m_nAuthor; }
+    // MACRO-1723
     void SetAuthor( std::size_t n )              { m_nAuthor = n; }
     const OUString& GetComment() const        { return m_sComment; }
     const DateTime& GetTimeStamp() const    { return m_aStamp; }
@@ -262,6 +263,7 @@ public:
     bool CanCombine( const SwRangeRedline& rRedl ) const;
 
     void PushData( const SwRangeRedline& rRedl, bool bOwnAsNext = true );
+    // MACRO-1723
     void PushData( const SwRedlineData& rData, bool bOwnAsNext = true );
     bool PopData();
     bool PopAllDataAfter(int depth);

--- a/libreoffice-core/sw/inc/redline.hxx
+++ b/libreoffice-core/sw/inc/redline.hxx
@@ -126,6 +126,7 @@ public:
     RedlineType GetType() const { return m_eType; }
 
     std::size_t GetAuthor() const                { return m_nAuthor; }
+    void SetAuthor( std::size_t n )              { m_nAuthor = n; }
     const OUString& GetComment() const        { return m_sComment; }
     const DateTime& GetTimeStamp() const    { return m_aStamp; }
     bool IsAnonymized() const
@@ -261,6 +262,7 @@ public:
     bool CanCombine( const SwRangeRedline& rRedl ) const;
 
     void PushData( const SwRangeRedline& rRedl, bool bOwnAsNext = true );
+    void PushData( const SwRedlineData& rData, bool bOwnAsNext = true );
     bool PopData();
     bool PopAllDataAfter(int depth);
 

--- a/libreoffice-core/sw/source/core/doc/DocumentRedlineManager.cxx
+++ b/libreoffice-core/sw/source/core/doc/DocumentRedlineManager.cxx
@@ -1921,13 +1921,17 @@ DocumentRedlineManager::AppendRedline(SwRangeRedline* pNewRedl, bool const bCall
 
                     case SwComparePosition::Inside:
                         {
+                            // Redlines have the same start position
                             if( *pRStt == *pStt )
                             {
                                 // #i97421#
                                 // redline w/out extent loops
+                                // new redline has some content
                                 if (*pStt != *pEnd)
                                 {
-                                    pNewRedl->PushData( *pRedl, false );
+
+                                    // MACRO :
+                                    /* pNewRedl->PushData( *pRedl, false ); */
                                     pRedl->SetStart( *pEnd, pRStt );
                                     // re-insert
                                     maRedlineTable.Remove( n );
@@ -1937,7 +1941,8 @@ DocumentRedlineManager::AppendRedline(SwRangeRedline* pNewRedl, bool const bCall
                             }
                             else
                             {
-                                pNewRedl->PushData( *pRedl, false );
+                                // MACRO :
+                                /* pNewRedl->PushData( *pRedl, false ); */
                                 if( *pREnd != *pEnd )
                                 {
                                     pNew = new SwRangeRedline( *pRedl );

--- a/libreoffice-core/sw/source/core/doc/DocumentRedlineManager.cxx
+++ b/libreoffice-core/sw/source/core/doc/DocumentRedlineManager.cxx
@@ -1930,7 +1930,8 @@ DocumentRedlineManager::AppendRedline(SwRangeRedline* pNewRedl, bool const bCall
                                 if (*pStt != *pEnd)
                                 {
 
-                                    // MACRO : {
+                                    // MACRO-1723: Fix Author when adding deletion within
+                                    // an existing insertion: {
                                     // Copy the redline data from the existing redline
                                     // but keep the author of the new redline
                                     SwRedlineData pTmp = pRedl->GetRedlineData();
@@ -1946,7 +1947,8 @@ DocumentRedlineManager::AppendRedline(SwRangeRedline* pNewRedl, bool const bCall
                             }
                             else
                             {
-                                // MACRO : {
+                                // MACRO-1723: Fix Author when adding deletion within
+                                // an existing insertion: {
                                 // Copy the redline data from the existing redline
                                 // but keep the author of the new redline
                                 SwRedlineData pTmp = pRedl->GetRedlineData();

--- a/libreoffice-core/sw/source/core/doc/DocumentRedlineManager.cxx
+++ b/libreoffice-core/sw/source/core/doc/DocumentRedlineManager.cxx
@@ -1930,8 +1930,13 @@ DocumentRedlineManager::AppendRedline(SwRangeRedline* pNewRedl, bool const bCall
                                 if (*pStt != *pEnd)
                                 {
 
-                                    // MACRO :
-                                    /* pNewRedl->PushData( *pRedl, false ); */
+                                    // MACRO : {
+                                    // Copy the redline data from the existing redline
+                                    // but keep the author of the new redline
+                                    SwRedlineData pTmp = pRedl->GetRedlineData();
+                                    pTmp.SetAuthor(pNewRedl->GetAuthor());
+                                    pNewRedl->PushData( pTmp, false );
+                                    // MACRO: }
                                     pRedl->SetStart( *pEnd, pRStt );
                                     // re-insert
                                     maRedlineTable.Remove( n );
@@ -1941,8 +1946,13 @@ DocumentRedlineManager::AppendRedline(SwRangeRedline* pNewRedl, bool const bCall
                             }
                             else
                             {
-                                // MACRO :
-                                /* pNewRedl->PushData( *pRedl, false ); */
+                                // MACRO : {
+                                // Copy the redline data from the existing redline
+                                // but keep the author of the new redline
+                                SwRedlineData pTmp = pRedl->GetRedlineData();
+                                pTmp.SetAuthor(pNewRedl->GetAuthor());
+                                pNewRedl->PushData( pTmp, false );
+                                // MACRO : }
                                 if( *pREnd != *pEnd )
                                 {
                                     pNew = new SwRangeRedline( *pRedl );

--- a/libreoffice-core/sw/source/core/doc/docredln.cxx
+++ b/libreoffice-core/sw/source/core/doc/docredln.cxx
@@ -2116,6 +2116,7 @@ void SwRangeRedline::PushData( const SwRangeRedline& rRedl, bool bOwnAsNext )
     }
 }
 
+// MACRO-1723: {
 void SwRangeRedline::PushData( const SwRedlineData& rData, bool bOwnAsNext)
 {
     SwRedlineData* pNew = new SwRedlineData(rData, false);
@@ -2130,6 +2131,7 @@ void SwRangeRedline::PushData( const SwRedlineData& rData, bool bOwnAsNext)
         m_pRedlineData->m_pNext = pNew;
     }
 }
+// MACRO: }
 
 bool SwRangeRedline::PopData()
 {

--- a/libreoffice-core/sw/source/core/doc/docredln.cxx
+++ b/libreoffice-core/sw/source/core/doc/docredln.cxx
@@ -2116,6 +2116,21 @@ void SwRangeRedline::PushData( const SwRangeRedline& rRedl, bool bOwnAsNext )
     }
 }
 
+void SwRangeRedline::PushData( const SwRedlineData& rData, bool bOwnAsNext)
+{
+    SwRedlineData* pNew = new SwRedlineData(rData, false);
+    if (bOwnAsNext)
+    {
+        pNew->m_pNext = m_pRedlineData;
+        m_pRedlineData = pNew;
+    }
+    else
+    {
+        pNew->m_pNext = m_pRedlineData->m_pNext;
+        m_pRedlineData->m_pNext = pNew;
+    }
+}
+
 bool SwRangeRedline::PopData()
 {
     if( !m_pRedlineData->m_pNext )


### PR DESCRIPTION
# Summary of PR
When you create a deletion redline inside the range of an existing insertion redline, the initial redline gets split up.

"Initial Test Redline"(Insertion)
---- *DELETE* "Test" ----
"Initial"(Insertion), "Test"(Deletion), "Redline"(Insertion) 

The existing code would push the RedlineData from the first "Initial" redline to the split "Test" redline.
But this is incorrect, because the "Test" redline has different author information.

These changes should be isolated exclusively to the case where you make a deletion within an existing insertion.

The inverse of this, making an insertion within an existing deletion currently works correctly, and it does not push the data to the split parts.

```cpp
case RedlineType::Insert:
    switch (pRedl->GetType())
    {
        // ... other cases ...

        case RedlineType::Delete:
            if (SwComparePosition::Inside == eCmpPos)
            {
                // split up
                if (*pEnd != *pREnd)
                {
                    SwRangeRedline* pCpy = new SwRangeRedline(*pRedl);
                    pCpy->SetStart(*pEnd);
                    maRedlineTable.Insert(pCpy);
                }
                pRedl->SetEnd(*pStt, pREnd);
                if ((*pStt == *pRStt) && (pRedl->GetContentIdx() == nullptr))
                {
                    maRedlineTable.DeleteAndDestroy(n);
                    bDec = true;
                }
                else if (!pRedl->HasValidRange())
                {
                    // re-insert
                    maRedlineTable.Remove(n);
                    maRedlineTable.Insert(pRedl);
                }
            }
            break;
    }
    break;

```

## Before you submit this PR
This is a **public, open source project**. Confidential or sensitive information should not be included in this description or any comments, including but not limited to links, files, and documents.

*If you're not certain that information is not confidential or sensitive in nature, do not include it.*

- [ ] I have verified that this PR does not include any confidential information
