### PR TITLE
FIX reject change removing formatting [MACRO-1781]

### DIFF
--- a/libreoffice-core/sw/source/core/doc/DocumentRedlineManager.cxx
+++ b/libreoffice-core/sw/source/core/doc/DocumentRedlineManager.cxx
@@ -911,20 +911,21 @@ namespace
                     // MACRO : MACRO-1781 {
                     // Instead of simply resetting all attributes, we only
                     // reset the attributes that were changed by the redline.
-                    if (const SwRedlineExtraData_FormatColl* pExtraData = dynamic_cast<const SwRedlineExtraData_FormatColl*>(pRedl->GetExtraData()))
+                    const SwRedlineExtraData_FormatColl* pExtraData =
+                        dynamic_cast<const SwRedlineExtraData_FormatColl*>(pRedl->GetExtraData());
+                    if (pExtraData)
                     {
+                        o3tl::sorted_vector<sal_uInt16> aResetAttrsArray;
 
-                    o3tl::sorted_vector<sal_uInt16> aResetAttrsArray;
+                        WhichRangesContainer rangesContainer = pExtraData->GetItemSet()->GetRanges();
 
-                    WhichRangesContainer rangesContainer = pExtraData->GetItemSet()->GetRanges();
+                        for (const auto& [nBegin, nEnd] : rangesContainer)
+                        {
+                            for (sal_uInt16 i = nBegin; i <= nEnd; ++i)
+                                aResetAttrsArray.insert( i );
+                        }
 
-                    for (const auto& [nBegin, nEnd] : rangesContainer)
-                    {
-                        for (sal_uInt16 i = nBegin; i <= nEnd; ++i)
-                            aResetAttrsArray.insert( i );
-                    }
-
-                    rDoc.ResetAttrs(aPam, false, aResetAttrsArray);
+                        rDoc.ResetAttrs(aPam, false, aResetAttrsArray);
                     }
                     // MACRO : MACRO-1781 }
                 }

--- a/libreoffice-core/sw/source/core/doc/DocumentRedlineManager.cxx
+++ b/libreoffice-core/sw/source/core/doc/DocumentRedlineManager.cxx
@@ -17,6 +17,7 @@
  *   the License at http://www.apache.org/licenses/LICENSE-2.0 .
 */
 #include "docfld.hxx"
+#include "svl/whichranges.hxx"
 #include <DocumentRedlineManager.hxx>
 #include <frmfmt.hxx>
 #include <rootfrm.hxx>
@@ -907,7 +908,25 @@ namespace
                 if ( pRedl->GetType() == RedlineType::Format )
                 {
                     SwPaM aPam( *(pRedl->Start()), *(pRedl->End()) );
-                    rDoc.ResetAttrs(aPam);
+                    // MACRO : MACRO-1781 {
+                    // Instead of simply resetting all attributes, we only
+                    // reset the attributes that were changed by the redline.
+                    if (const SwRedlineExtraData_FormatColl* pExtraData = dynamic_cast<const SwRedlineExtraData_FormatColl*>(pRedl->GetExtraData()))
+                    {
+
+                    o3tl::sorted_vector<sal_uInt16> aResetAttrsArray;
+
+                    WhichRangesContainer rangesContainer = pExtraData->GetItemSet()->GetRanges();
+
+                    for (const auto& [nBegin, nEnd] : rangesContainer)
+                    {
+                        for (sal_uInt16 i = nBegin; i <= nEnd; ++i)
+                            aResetAttrsArray.insert( i );
+                    }
+
+                    rDoc.ResetAttrs(aPam, false, aResetAttrsArray);
+                    }
+                    // MACRO : MACRO-1781 }
                 }
                 else if ( pRedl->GetType() == RedlineType::ParagraphFormat )
                 {


### PR DESCRIPTION
# Summary of PR
Instead of fully resetting all attributes when we reject a formatting change, we only reset those associated with the redline.

## Before you submit this PR
This is a **public, open source project**. Confidential or sensitive information should not be included in this description or any comments, including but not limited to links, files, and documents.

*If you're not certain that information is not confidential or sensitive in nature, do not include it.*

- [ ] I have verified that this PR does not include any confidential information
